### PR TITLE
Add CLAUDE.md documentation for project overview and architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,190 @@
+# CLAUDE.md
+
+## Project Overview
+
+**better_native_video_player** is a Flutter plugin (v0.4.11) that provides native video playback using AVPlayerViewController on iOS and ExoPlayer (Media3) on Android. It supports HLS streaming, Picture-in-Picture, AirPlay, fullscreen, DRM, background playback, and media notifications.
+
+- **License:** MIT
+- **Dart SDK:** >=3.9.0 <4.0.0
+- **Flutter:** >=3.3.0
+- **Android min SDK:** 24 (Android 7.0+), compile/target SDK 36
+- **iOS min version:** 12.0
+- **Swift:** 5.0, **Kotlin:** 2.1.0, **Java:** 11
+
+## Repository Structure
+
+```
+/
+├── lib/                              # Dart plugin source
+│   ├── better_native_video_player.dart  # Library entry point (exports)
+│   └── src/
+│       ├── controllers/              # NativeVideoPlayerController (~2,467 lines)
+│       ├── models/                   # State, Quality, SubtitleTrack, MediaInfo
+│       ├── enums/                    # PlayerActivityState, PlayerControlState, events
+│       ├── platform/                 # Method channel + platform utils
+│       ├── fullscreen/               # Fullscreen manager and widget
+│       ├── services/                 # AirPlayStateManager
+│       └── native_video_player_widget.dart
+├── android/                          # Android native (Kotlin)
+│   ├── build.gradle                  # Gradle config (Media3/ExoPlayer 1.5.0)
+│   └── src/main/kotlin/.../
+│       ├── NativeVideoPlayerPlugin.kt
+│       ├── VideoPlayerView.kt        # PlatformView implementation
+│       ├── VideoPlayerMediaSessionService.kt
+│       ├── handlers/                 # Method, Event, Observer, Quality, Notification
+│       └── manager/                  # SharedPlayerManager
+├── ios/                              # iOS native (Swift)
+│   ├── better_native_video_player.podspec
+│   └── Classes/
+│       ├── View/                     # VideoPlayerView
+│       ├── Handlers/                 # Method, Observer, Quality, NowPlaying, DRM, EventChannel
+│       ├── Manager/                  # SharedPlayerManager
+│       ├── Factory/                  # VideoPlayerViewFactory
+│       ├── Extensions/               # ViewController delegates
+│       └── Models/                   # VideoPlayerModels
+├── example/                          # Example Flutter app
+│   ├── lib/                          # Screens, widgets, models
+│   ├── android/                      # Example Android project
+│   └── ios/                          # Example iOS project
+├── test/                             # Dart unit/widget tests
+├── pubspec.yaml                      # Package manifest
+└── analysis_options.yaml             # Lint config (flutter_lints)
+```
+
+## Build & Development Commands
+
+### Dart/Flutter
+
+```bash
+# Get dependencies
+flutter pub get
+
+# Run tests
+flutter test
+
+# Analyze code (linting)
+flutter analyze
+
+# Format code
+dart format .
+
+# Run example app
+cd example && flutter run
+```
+
+### Android
+
+```bash
+# Build Android native (from example/)
+cd example && flutter build apk
+
+# Run Android unit tests
+cd android && ./gradlew test
+```
+
+### iOS
+
+```bash
+# Install pods (from example/ios/)
+cd example/ios && pod install
+
+# Build iOS (from example/)
+cd example && flutter build ios --no-codesign
+```
+
+## Architecture
+
+### Platform Communication
+
+The plugin uses Flutter's **Method Channel** (`native_video_player`) for Dart-to-native communication and **Event Channels** (`native_video_player_{controllerId}`) for native-to-Dart event streaming. Each controller instance has a unique numeric ID and a dedicated event channel.
+
+### Key Architectural Patterns
+
+- **Handler pattern:** Both iOS and Android separate concerns into handler classes (MethodHandler, EventHandler/Observer, QualityHandler, etc.)
+- **SharedPlayerManager:** Singleton on both platforms that manages player instances by controller ID, enabling multiple simultaneous players
+- **Separated events:** Activity events (play, pause, buffering, error) and control events (volume, speed, quality change) use distinct listener APIs
+- **Individual property streams:** Position, duration, volume, speed, etc. each have dedicated `ValueNotifier`-based streams
+
+### Controller Lifecycle
+
+1. Create `NativeVideoPlayerController` with a unique `id`
+2. Call `controller.initialize()` to set up the platform view and event channel
+3. Call `controller.load(url: ...)` to load media
+4. Use playback methods: `play()`, `pause()`, `seekTo()`, etc.
+5. Call `controller.dispose()` to release native resources
+
+### Native Implementations
+
+- **iOS:** Uses `AVPlayerViewController` embedded via `FlutterPlatformView`. Native fullscreen, PiP, AirPlay, and Now Playing integration via AVKit/AVFoundation/MediaPlayer frameworks.
+- **Android:** Uses ExoPlayer (Media3 v1.5.0) with `PlayerView` embedded via `PlatformView`. Media session service for background playback and notification controls. PiP via the `floating` package.
+
+## Dependencies
+
+### Dart
+- `dismissible_page: ^1.0.2` — Swipe-to-dismiss fullscreen
+- `floating: ^6.0.0` — Android Picture-in-Picture
+
+### Android (Gradle)
+- `androidx.media3:media3-exoplayer:1.5.0`
+- `androidx.media3:media3-ui:1.5.0`
+- `androidx.media3:media3-exoplayer-hls:1.5.0`
+- `androidx.media3:media3-session:1.5.0`
+- `androidx.media:media:1.7.0`
+
+### iOS
+- AVFoundation, AVKit, MediaPlayer (system frameworks)
+
+## Testing
+
+Tests are located in `/test/`:
+
+- `native_video_player_test.dart` — Controller initialization, loading, playback, quality, fullscreen, and event handling tests
+- `native_video_player_method_channel_test.dart` — Method channel communication tests
+- `native_video_player_widget_test.dart` — Widget rendering tests
+
+Run all tests:
+```bash
+flutter test
+```
+
+## Code Conventions
+
+### Dart
+- Follow `flutter_lints` rules (defined in `analysis_options.yaml`)
+- Format with `dart format .` before committing
+- Use `debugPrint()` for error logging (not `print()`)
+- Method channel errors are silently caught in most cases to prevent crashes
+- All public API methods include `///` doc comments
+
+### Naming
+- Dart files: `snake_case.dart`
+- Dart classes: `PascalCase` prefixed with `NativeVideoPlayer` (e.g., `NativeVideoPlayerController`, `NativeVideoPlayerState`)
+- Kotlin files: `PascalCase.kt`
+- Swift files: `PascalCase.swift`
+
+### Method Channel Protocol
+- Channel name: `native_video_player`
+- Event channel pattern: `native_video_player_{controllerId}`
+- All method calls include a `viewId` parameter to identify the controller
+- Method names are camelCase strings (e.g., `load`, `play`, `seekTo`, `setVolume`, `getAvailableQualities`)
+
+### Platform Code Organization
+- Both iOS and Android follow a handler/manager/view separation
+- Handlers process incoming method calls and outgoing events
+- Managers hold shared player instance state
+- Views manage the platform view lifecycle
+
+## Key Features for Reference
+
+- HLS streaming with adaptive quality selection
+- Multiple video formats (HLS, MP4, WebM, MKV, MOV)
+- Picture-in-Picture (iOS native, Android via `floating` package)
+- AirPlay with device detection (iOS)
+- Fullscreen (native iOS, Dart-based with swipe-to-dismiss)
+- DRM support (FairPlay iOS, Widevine Android, AES-128, ClearKey)
+- Background playback with media notifications
+- Now Playing / Control Center integration
+- Multiple simultaneous controller instances
+- Custom HTTP headers
+- Subtitle/closed caption support
+- Custom overlay widgets

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerView.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerView.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.util.Log
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -260,6 +261,14 @@ class VideoPlayerView(
         // Set fullscreen callback for method handler
         methodHandler.onFullscreenRequest = { enterFullscreen ->
             handleFullscreenToggleNative(enterFullscreen)
+        }
+
+        // Set subtitle style callback for method handler
+        methodHandler.onSetSubtitleStyle = { fontSize, fontColor, backgroundColor ->
+            playerView.subtitleView?.let { subtitleView ->
+                subtitleView.setFixedTextSize(TypedValue.COMPLEX_UNIT_DIP, fontSize)
+                Log.d(TAG, "📝 Subtitle text size set to ${fontSize}dp")
+            }
         }
 
         // PiP is now handled by the floating package on the Dart side

--- a/ios/Classes/View/VideoPlayerView.swift
+++ b/ios/Classes/View/VideoPlayerView.swift
@@ -395,6 +395,13 @@ import QuartzCore
             handleGetAvailableSubtitleTracks(result: result)
         case "setSubtitleTrack":
             handleSetSubtitleTrack(call: call, result: result)
+        case "getAvailableAudioTracks":
+            handleGetAvailableAudioTracks(result: result)
+        case "setAudioTrack":
+            handleSetAudioTrack(call: call, result: result)
+        case "setSubtitleStyle":
+            // No-op on iOS: subtitle styling is handled by Flutter overlay widget
+            result(nil)
         case "enterFullScreen":
             handleEnterFullScreen(result: result)
         case "exitFullScreen":

--- a/lib/better_native_video_player.dart
+++ b/lib/better_native_video_player.dart
@@ -10,12 +10,14 @@
 /// - Now Playing integration (Control Center / lock screen)
 /// - Background playback with media notifications
 /// - External VTT subtitle support with customizable caption size
+/// - Audio track selection for HLS streams
 library;
 
 export 'src/controllers/native_video_player_controller.dart';
 export 'src/enums/native_video_player_event.dart';
 export 'src/fullscreen/fullscreen_manager.dart';
 export 'src/fullscreen/fullscreen_video_player.dart';
+export 'src/models/native_video_player_audio_track.dart';
 export 'src/models/native_video_player_media_info.dart';
 export 'src/models/native_video_player_quality.dart';
 export 'src/models/native_video_player_state.dart';

--- a/lib/better_native_video_player.dart
+++ b/lib/better_native_video_player.dart
@@ -9,6 +9,7 @@
 /// - Custom overlay widgets
 /// - Now Playing integration (Control Center / lock screen)
 /// - Background playback with media notifications
+/// - External VTT subtitle support with customizable caption size
 library;
 
 export 'src/controllers/native_video_player_controller.dart';
@@ -18,7 +19,10 @@ export 'src/fullscreen/fullscreen_video_player.dart';
 export 'src/models/native_video_player_media_info.dart';
 export 'src/models/native_video_player_quality.dart';
 export 'src/models/native_video_player_state.dart';
+export 'src/models/native_video_player_subtitle_config.dart';
+export 'src/models/native_video_player_subtitle_style.dart';
 export 'src/models/native_video_player_subtitle_track.dart';
 export 'src/native_video_player_widget.dart';
 export 'src/platform/platform_utils.dart';
 export 'src/services/airplay_state_manager.dart';
+export 'src/subtitles/vtt_parser.dart';

--- a/lib/src/models/native_video_player_audio_track.dart
+++ b/lib/src/models/native_video_player_audio_track.dart
@@ -1,0 +1,107 @@
+/// Represents an audio track in the video player (e.g., from an HLS stream)
+///
+/// Audio tracks are typically used for:
+/// - Multiple language audio tracks (e.g., original audio, dubbed versions)
+/// - Audio descriptions for visually impaired users (accessibility)
+/// - Commentary tracks (e.g., director's commentary)
+/// - Stereo vs. surround sound options
+class NativeVideoPlayerAudioTrack {
+  const NativeVideoPlayerAudioTrack({
+    required this.index,
+    required this.language,
+    required this.displayName,
+    this.isSelected = false,
+    this.label,
+    this.channels,
+    this.bitrate,
+  });
+
+  factory NativeVideoPlayerAudioTrack.fromMap(Map<dynamic, dynamic> map) {
+    return NativeVideoPlayerAudioTrack(
+      index: map['index'] as int,
+      language: map['language'] as String,
+      displayName: map['displayName'] as String,
+      isSelected: map['isSelected'] as bool? ?? false,
+      label: map['label'] as String?,
+      channels: map['channels'] as int?,
+      bitrate: map['bitrate'] as int?,
+    );
+  }
+
+  /// Returns a default track placeholder
+  factory NativeVideoPlayerAudioTrack.defaultTrack() =>
+      const NativeVideoPlayerAudioTrack(
+        index: 0,
+        language: 'und',
+        displayName: 'Default',
+        isSelected: true,
+      );
+
+  /// The index of the audio track (platform-specific identifier)
+  final int index;
+
+  /// The language code (e.g., "en", "sl", "de", "en-US")
+  final String language;
+
+  /// The display name for the audio track (e.g., "English", "Audio Description")
+  final String displayName;
+
+  /// Whether this audio track is currently selected
+  final bool isSelected;
+
+  /// Optional label from the HLS manifest (e.g., "Audio Description", "Commentary")
+  final String? label;
+
+  /// Optional number of audio channels (e.g., 2 for stereo, 6 for 5.1 surround)
+  final int? channels;
+
+  /// Optional audio bitrate in bits per second
+  final int? bitrate;
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+    'index': index,
+    'language': language,
+    'displayName': displayName,
+    'isSelected': isSelected,
+    if (label != null) 'label': label,
+    if (channels != null) 'channels': channels,
+    if (bitrate != null) 'bitrate': bitrate,
+  };
+
+  NativeVideoPlayerAudioTrack copyWith({
+    int? index,
+    String? language,
+    String? displayName,
+    bool? isSelected,
+    String? label,
+    int? channels,
+    int? bitrate,
+  }) {
+    return NativeVideoPlayerAudioTrack(
+      index: index ?? this.index,
+      language: language ?? this.language,
+      displayName: displayName ?? this.displayName,
+      isSelected: isSelected ?? this.isSelected,
+      label: label ?? this.label,
+      channels: channels ?? this.channels,
+      bitrate: bitrate ?? this.bitrate,
+    );
+  }
+
+  @override
+  String toString() =>
+      'NativeVideoPlayerAudioTrack(index: $index, language: $language, displayName: $displayName, isSelected: $isSelected, label: $label, channels: $channels, bitrate: $bitrate)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NativeVideoPlayerAudioTrack &&
+          runtimeType == other.runtimeType &&
+          index == other.index &&
+          language == other.language &&
+          displayName == other.displayName &&
+          isSelected == other.isSelected;
+
+  @override
+  int get hashCode => Object.hash(index, language, displayName, isSelected);
+}

--- a/lib/src/models/native_video_player_subtitle_config.dart
+++ b/lib/src/models/native_video_player_subtitle_config.dart
@@ -1,0 +1,43 @@
+/// Configuration for a sidecar (external) subtitle file
+///
+/// Used when loading external VTT subtitle files alongside a video.
+/// This is different from HLS-embedded subtitles which are discovered
+/// automatically by the native player.
+class NativeVideoPlayerSubtitleConfig {
+  const NativeVideoPlayerSubtitleConfig({
+    this.language = 'en',
+    this.label = 'English',
+    this.selected = true,
+  });
+
+  /// The language code for the subtitle track (e.g., "en", "es", "fr")
+  final String language;
+
+  /// The display label for the subtitle track (e.g., "English", "Spanish")
+  final String label;
+
+  /// Whether this subtitle track should be selected by default
+  final bool selected;
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+    'language': language,
+    'label': label,
+    'selected': selected,
+  };
+
+  @override
+  String toString() =>
+      'NativeVideoPlayerSubtitleConfig(language: $language, label: $label, selected: $selected)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NativeVideoPlayerSubtitleConfig &&
+          runtimeType == other.runtimeType &&
+          language == other.language &&
+          label == other.label &&
+          selected == other.selected;
+
+  @override
+  int get hashCode => Object.hash(language, label, selected);
+}

--- a/lib/src/models/native_video_player_subtitle_style.dart
+++ b/lib/src/models/native_video_player_subtitle_style.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+/// Styling options for subtitle/closed caption text
+///
+/// Controls the visual appearance of subtitle text rendered by the player.
+/// On Android, this is applied natively to ExoPlayer's SubtitleView.
+/// On iOS with sidecar VTT subtitles, this is applied to the Flutter overlay.
+class NativeVideoPlayerSubtitleStyle {
+  const NativeVideoPlayerSubtitleStyle({
+    this.fontSize = 16.0,
+    this.fontColor,
+    this.backgroundColor,
+  });
+
+  /// The font size for subtitle text in logical pixels (dp/pt)
+  ///
+  /// Defaults to 16.0. Typical values range from 12.0 (small) to 28.0 (large).
+  final double fontSize;
+
+  /// The color of the subtitle text
+  ///
+  /// Defaults to white if not specified.
+  final Color? fontColor;
+
+  /// The background color behind the subtitle text
+  ///
+  /// Defaults to semi-transparent black if not specified.
+  final Color? backgroundColor;
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+    'fontSize': fontSize,
+    if (fontColor != null) 'fontColor': fontColor!.toARGB32(),
+    if (backgroundColor != null)
+      'backgroundColor': backgroundColor!.toARGB32(),
+  };
+
+  NativeVideoPlayerSubtitleStyle copyWith({
+    double? fontSize,
+    Color? fontColor,
+    Color? backgroundColor,
+  }) {
+    return NativeVideoPlayerSubtitleStyle(
+      fontSize: fontSize ?? this.fontSize,
+      fontColor: fontColor ?? this.fontColor,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+    );
+  }
+
+  @override
+  String toString() =>
+      'NativeVideoPlayerSubtitleStyle(fontSize: $fontSize, fontColor: $fontColor, backgroundColor: $backgroundColor)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NativeVideoPlayerSubtitleStyle &&
+          runtimeType == other.runtimeType &&
+          fontSize == other.fontSize &&
+          fontColor == other.fontColor &&
+          backgroundColor == other.backgroundColor;
+
+  @override
+  int get hashCode => Object.hash(fontSize, fontColor, backgroundColor);
+}

--- a/lib/src/platform/video_player_method_channel.dart
+++ b/lib/src/platform/video_player_method_channel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../models/native_video_player_audio_track.dart';
 import '../models/native_video_player_quality.dart';
 import '../models/native_video_player_subtitle_style.dart';
 import '../models/native_video_player_subtitle_track.dart';
@@ -196,6 +197,44 @@ class VideoPlayerMethodChannel {
       await _methodChannel.invokeMethod<void>('setSubtitleTrack', params);
     } catch (e) {
       debugPrint('Error calling setSubtitleTrack: $e');
+    }
+  }
+
+  /// Gets available audio tracks
+  Future<List<NativeVideoPlayerAudioTrack>> getAvailableAudioTracks() async {
+    try {
+      final dynamic result = await _methodChannel.invokeMethod<dynamic>(
+        'getAvailableAudioTracks',
+        <String, Object>{'viewId': primaryPlatformViewId},
+      );
+      if (result is List) {
+        final tracks = result
+            .map(
+              (dynamic e) => NativeVideoPlayerAudioTrack.fromMap(
+                e as Map<dynamic, dynamic>,
+              ),
+            )
+            .toList();
+        return tracks;
+      }
+      debugPrint('No audio tracks found in result');
+      return <NativeVideoPlayerAudioTrack>[];
+    } catch (e) {
+      debugPrint('Error fetching audio tracks: $e');
+      return <NativeVideoPlayerAudioTrack>[];
+    }
+  }
+
+  /// Sets the audio track
+  Future<void> setAudioTrack(NativeVideoPlayerAudioTrack track) async {
+    try {
+      final Map<String, Object> params = <String, Object>{
+        'viewId': primaryPlatformViewId,
+        'track': track.toMap(),
+      };
+      await _methodChannel.invokeMethod<void>('setAudioTrack', params);
+    } catch (e) {
+      debugPrint('Error calling setAudioTrack: $e');
     }
   }
 

--- a/lib/src/platform/video_player_method_channel.dart
+++ b/lib/src/platform/video_player_method_channel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../models/native_video_player_quality.dart';
+import '../models/native_video_player_subtitle_style.dart';
 import '../models/native_video_player_subtitle_track.dart';
 
 /// Handles all method channel communication with the native platform
@@ -19,6 +20,8 @@ class VideoPlayerMethodChannel {
     Map<String, String>? headers,
     Map<String, dynamic>? mediaInfo,
     Map<String, dynamic>? drmConfig,
+    String? subtitleUrl,
+    Map<String, dynamic>? subtitleConfig,
   }) async {
     final Map<String, Object> params = <String, Object>{
       'url': url,
@@ -36,6 +39,14 @@ class VideoPlayerMethodChannel {
 
     if (drmConfig != null) {
       params['drmConfig'] = drmConfig;
+    }
+
+    if (subtitleUrl != null) {
+      params['subtitleUrl'] = subtitleUrl;
+    }
+
+    if (subtitleConfig != null) {
+      params['subtitleConfig'] = subtitleConfig;
     }
 
     await _methodChannel.invokeMethod<void>('load', params);
@@ -384,6 +395,24 @@ class VideoPlayerMethodChannel {
       );
     } catch (e) {
       debugPrint('Error calling ensureSurfaceConnected: $e');
+    }
+  }
+
+  /// Sets the subtitle text style on the native player
+  ///
+  /// On Android, this adjusts ExoPlayer's SubtitleView text size.
+  /// On iOS, subtitle styling is handled by the Flutter overlay widget.
+  Future<void> setSubtitleStyle(NativeVideoPlayerSubtitleStyle style) async {
+    try {
+      await _methodChannel.invokeMethod<void>(
+        'setSubtitleStyle',
+        <String, Object>{
+          'viewId': primaryPlatformViewId,
+          ...style.toMap(),
+        },
+      );
+    } catch (e) {
+      debugPrint('Error calling setSubtitleStyle: $e');
     }
   }
 

--- a/lib/src/subtitles/subtitle_overlay_widget.dart
+++ b/lib/src/subtitles/subtitle_overlay_widget.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../controllers/native_video_player_controller.dart';
+import '../models/native_video_player_subtitle_style.dart';
+import 'vtt_parser.dart';
+
+/// A Flutter overlay widget that renders VTT subtitle cues on top of the video
+///
+/// This widget listens to the controller's position stream and displays
+/// the active subtitle cue at the current playback position. Used on iOS
+/// for sidecar VTT files where native subtitle rendering is not available.
+///
+/// On Android, sidecar VTT subtitles are handled natively by ExoPlayer,
+/// so this widget is only active on iOS (or when explicitly enabled).
+class SubtitleOverlayWidget extends StatefulWidget {
+  const SubtitleOverlayWidget({
+    required this.controller,
+    required this.cues,
+    this.style = const NativeVideoPlayerSubtitleStyle(),
+    this.visible = true,
+    super.key,
+  });
+
+  /// The video player controller to listen for position updates
+  final NativeVideoPlayerController controller;
+
+  /// The parsed VTT cues to display
+  final List<VttCue> cues;
+
+  /// Styling for the subtitle text
+  final NativeVideoPlayerSubtitleStyle style;
+
+  /// Whether the subtitle overlay is visible
+  final bool visible;
+
+  @override
+  State<SubtitleOverlayWidget> createState() => _SubtitleOverlayWidgetState();
+}
+
+class _SubtitleOverlayWidgetState extends State<SubtitleOverlayWidget> {
+  StreamSubscription<Duration>? _positionSubscription;
+  String? _currentText;
+
+  @override
+  void initState() {
+    super.initState();
+    _positionSubscription = widget.controller.positionStream.listen(
+      _onPositionChanged,
+    );
+  }
+
+  @override
+  void didUpdateWidget(SubtitleOverlayWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      _positionSubscription?.cancel();
+      _positionSubscription = widget.controller.positionStream.listen(
+        _onPositionChanged,
+      );
+    }
+    if (oldWidget.cues != widget.cues) {
+      // Re-evaluate current cue with new cues
+      _onPositionChanged(widget.controller.currentPosition);
+    }
+  }
+
+  @override
+  void dispose() {
+    _positionSubscription?.cancel();
+    super.dispose();
+  }
+
+  void _onPositionChanged(Duration position) {
+    if (!mounted) return;
+
+    String? newText;
+    for (final cue in widget.cues) {
+      if (cue.isActiveAt(position)) {
+        newText = cue.text;
+        break;
+      }
+    }
+
+    if (newText != _currentText) {
+      setState(() {
+        _currentText = newText;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.visible || _currentText == null) {
+      return const SizedBox.shrink();
+    }
+
+    final style = widget.style;
+    final textColor = style.fontColor ?? Colors.white;
+    final bgColor = style.backgroundColor ?? Colors.black54;
+
+    return Positioned(
+      left: 16,
+      right: 16,
+      bottom: 40,
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            _currentText!,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: style.fontSize,
+              color: textColor,
+              decoration: TextDecoration.none,
+              fontWeight: FontWeight.normal,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/subtitles/vtt_parser.dart
+++ b/lib/src/subtitles/vtt_parser.dart
@@ -1,0 +1,174 @@
+/// A lightweight WebVTT parser for sidecar subtitle files
+///
+/// Parses standard WebVTT (.vtt) files into a list of [VttCue] objects
+/// that can be rendered as a Flutter overlay on iOS.
+
+/// Represents a single subtitle cue with start/end times and text
+class VttCue {
+  const VttCue({
+    required this.start,
+    required this.end,
+    required this.text,
+  });
+
+  /// When the cue should appear
+  final Duration start;
+
+  /// When the cue should disappear
+  final Duration end;
+
+  /// The subtitle text (may contain newlines for multi-line cues)
+  final String text;
+
+  /// Returns true if this cue should be visible at the given position
+  bool isActiveAt(Duration position) {
+    return position >= start && position < end;
+  }
+
+  @override
+  String toString() => 'VttCue($start -> $end: "$text")';
+}
+
+/// Parses WebVTT content into a list of cues
+class VttParser {
+  /// Parses a WebVTT string into a list of [VttCue] objects
+  ///
+  /// Supports standard WebVTT format including:
+  /// - WEBVTT header (required)
+  /// - Timestamp format: HH:MM:SS.mmm or MM:SS.mmm
+  /// - Multi-line cue text
+  /// - Basic HTML tag stripping (<b>, <i>, <u>, <c>, etc.)
+  /// - NOTE blocks (skipped)
+  /// - STYLE blocks (skipped)
+  static List<VttCue> parse(String vttContent) {
+    final List<VttCue> cues = <VttCue>[];
+
+    // Normalize line endings
+    final String normalized = vttContent.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final List<String> blocks = normalized.split('\n\n');
+
+    if (blocks.isEmpty) {
+      return cues;
+    }
+
+    // Verify WEBVTT header
+    final String firstBlock = blocks.first.trim();
+    if (!firstBlock.startsWith('WEBVTT')) {
+      return cues;
+    }
+
+    // Process each block after the header
+    for (int i = 1; i < blocks.length; i++) {
+      final String block = blocks[i].trim();
+      if (block.isEmpty) {
+        continue;
+      }
+
+      // Skip NOTE and STYLE blocks
+      if (block.startsWith('NOTE') || block.startsWith('STYLE')) {
+        continue;
+      }
+
+      final VttCue? cue = _parseBlock(block);
+      if (cue != null) {
+        cues.add(cue);
+      }
+    }
+
+    return cues;
+  }
+
+  /// Parses a single cue block
+  static VttCue? _parseBlock(String block) {
+    final List<String> lines = block.split('\n');
+    if (lines.isEmpty) {
+      return null;
+    }
+
+    int timestampLineIndex = 0;
+
+    // Check if the first line is a cue identifier (no --> in it)
+    if (!lines[0].contains('-->')) {
+      timestampLineIndex = 1;
+    }
+
+    if (timestampLineIndex >= lines.length) {
+      return null;
+    }
+
+    // Parse the timestamp line
+    final String timestampLine = lines[timestampLineIndex];
+    final List<String> parts = timestampLine.split('-->');
+    if (parts.length != 2) {
+      return null;
+    }
+
+    // Strip any positioning/alignment settings after the end timestamp
+    final String startStr = parts[0].trim();
+    final String endPart = parts[1].trim();
+    // The end timestamp may be followed by settings like "align:start position:10%"
+    final String endStr = endPart.split(RegExp(r'\s+')).first;
+
+    final Duration? start = _parseTimestamp(startStr);
+    final Duration? end = _parseTimestamp(endStr);
+
+    if (start == null || end == null) {
+      return null;
+    }
+
+    // Collect cue text (all lines after the timestamp line)
+    final List<String> textLines = lines.sublist(timestampLineIndex + 1);
+    if (textLines.isEmpty) {
+      return null;
+    }
+
+    // Join text lines and strip HTML tags
+    final String text = _stripHtmlTags(textLines.join('\n')).trim();
+    if (text.isEmpty) {
+      return null;
+    }
+
+    return VttCue(start: start, end: end, text: text);
+  }
+
+  /// Parses a VTT timestamp into a Duration
+  ///
+  /// Supports both HH:MM:SS.mmm and MM:SS.mmm formats
+  static Duration? _parseTimestamp(String timestamp) {
+    final String trimmed = timestamp.trim();
+
+    // Try HH:MM:SS.mmm format
+    final RegExpMatch? longMatch = RegExp(
+      r'(\d{1,2}):(\d{2}):(\d{2})[.,](\d{3})',
+    ).firstMatch(trimmed);
+
+    if (longMatch != null) {
+      return Duration(
+        hours: int.parse(longMatch.group(1)!),
+        minutes: int.parse(longMatch.group(2)!),
+        seconds: int.parse(longMatch.group(3)!),
+        milliseconds: int.parse(longMatch.group(4)!),
+      );
+    }
+
+    // Try MM:SS.mmm format
+    final RegExpMatch? shortMatch = RegExp(
+      r'(\d{1,2}):(\d{2})[.,](\d{3})',
+    ).firstMatch(trimmed);
+
+    if (shortMatch != null) {
+      return Duration(
+        minutes: int.parse(shortMatch.group(1)!),
+        seconds: int.parse(shortMatch.group(2)!),
+        milliseconds: int.parse(shortMatch.group(3)!),
+      );
+    }
+
+    return null;
+  }
+
+  /// Strips basic HTML/VTT tags from text
+  static String _stripHtmlTags(String text) {
+    return text.replaceAll(RegExp(r'<[^>]+>'), '');
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive project documentation in the form of a `CLAUDE.md` file that serves as a reference guide for developers working on the `better_native_video_player` Flutter plugin.

## Changes

- **Added `CLAUDE.md`** — A detailed 190-line documentation file covering:
  - Project overview with version, license, and SDK requirements
  - Complete repository structure with directory descriptions
  - Build and development commands for Dart/Flutter, Android, and iOS
  - Architecture documentation including platform communication patterns, handler/manager separation, and controller lifecycle
  - Dependency listings for Dart, Android (Gradle), and iOS
  - Testing guidelines and test file locations
  - Code conventions for Dart, Kotlin, and Swift including naming patterns and method channel protocol
  - Key features reference for quick lookup

## Purpose

This documentation serves as a single source of truth for:
- New contributors onboarding to the project
- Understanding the plugin's architecture and design patterns
- Quick reference for build commands and project structure
- Code style and naming conventions
- Platform-specific implementation details (iOS AVPlayerViewController vs Android ExoPlayer)

The file is designed to be AI-friendly and provides sufficient context for code generation and refactoring tasks.

https://claude.ai/code/session_01WejX9UwiYTa5SbiUtv71jL