### PR TITLE
[iOS][Fix] iOS Player "fullscreen" status not dected if started from the native player's button

### DIFF
--- a/ios/Classes/Extensions/VideoPlayerViewController+Delegate.swift
+++ b/ios/Classes/Extensions/VideoPlayerViewController+Delegate.swift
@@ -224,6 +224,20 @@ extension VideoPlayerView: AVPlayerViewControllerDelegate {
             }
         }
     }
+    
+    @available(iOS 12.0, *)
+    public func playerViewController(
+        _ playerViewController: AVPlayerViewController,
+        willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
+    ) {
+        coordinator.animate(alongsideTransition: nil) { context in
+            if !context.isCancelled {
+                // Fullscreen entered
+                self.fullscreenPlayerViewController = playerViewController
+                self.sendEvent("fullscreenChange", data: ["isFullscreen": true])
+            }
+        }
+    }
 }
 
 // MARK: - AVPictureInPictureControllerDelegate


### PR DESCRIPTION
Hello,

I noticed that the `isFullScreenStream` stream on dart layer was not reacting at all whenever i pressed the "fullscreen" button from the native AVPlayerController buttons. After checking the iOS Platform code i detected the delegate `willBeginFullScreenPresentationWithAnimationCoordinator ` wasn't set in the `VideoPlayerViewController` delegate file. In order to make this work, i just overridden the function and then called the state change so that it would be reflected in the dart layer as well.

I also assigned the `fullscreenPlayerViewController ` instance since on the delegate function called when the fullscreen player is dismissed it was present, however it was never initialized.

Thank you in advance