### PR TITLE
release: 1.3.0 — quality audio fix, qualityChangedStream, Android background playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-23
+
+Quality-selection and Android background-playback fixes.
+
+### Fixed
+- **Quality switching no longer drops audio (iOS + Android).** Selecting an HLS quality — or switching back to Auto — previously reloaded a single video-only variant playlist, replacing the master. On adaptive streams that carry audio as a separate rendition (`#EXT-X-MEDIA:TYPE=AUDIO`), that silenced the audio while video kept playing. The plugin now keeps the master loaded and constrains the **video track** via the player's track selector (`preferredMaximumResolution`/`preferredPeakBitRate` on iOS, `setMaxVideoSize`/`setMaxVideoBitrate` on Android), so audio is untouched and the switch is instant (no buffering reload).
+- **`qualityChangedStream` now emits the selected quality.** Native emits the quality fields flat in the event map, but the Dart handler only accepted a nested `quality` key, so the stream stayed silent and any UI bound to it was stuck on "Auto". The handler now accepts both shapes.
+- **iOS: position/time updates no longer stop when Auto quality is enabled.** The old auto-quality monitor reused the shared periodic time observer that drives `timeUpdate`, clobbering position reporting. The monitor is removed — AVPlayer's native ABR handles Auto.
+- **Android: background playback (live + VOD) no longer dies after a few minutes.** The plugin posted a media notification but never ran a real foreground service, so Doze/App-Standby cut the app's network and ExoPlayer failed with `UnknownHostException`. Playback now runs as a real foreground service while playing (stopped on pause/stop), and the shared player uses `setWakeMode(WAKE_MODE_NETWORK)` (partial WakeLock + WifiLock). Adds the `WAKE_LOCK` permission to the plugin manifest.
+
 ## [1.2.1] - 2026-06-22
 
 Android Picture-in-Picture subtitle fix.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,17 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <!-- Media Session Service for video playback notifications and background playback -->
+        <!-- Foreground service that keeps the app's network alive for background
+             video playback (live + VOD). Started only while playing. -->
         <service
             android:name="com.huddlecommunity.better_native_video_player.VideoPlayerMediaSessionService"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback">
-            <intent-filter>
-                <action android:name="androidx.media3.session.MediaSessionService" />
-            </intent-filter>
-        </service>
+            android:foregroundServiceType="mediaPlayback" />
     </application>
 
     <!-- Required for media playback -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- Required by ExoPlayer setWakeMode(WAKE_MODE_NETWORK): partial WakeLock +
+         WifiLock keep the CPU/WiFi radio awake during background playback. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerMediaSessionService.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerMediaSessionService.kt
@@ -1,93 +1,136 @@
 package com.huddlecommunity.better_native_video_player
 
-import android.app.PendingIntent
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
 import android.content.Intent
-import android.os.Bundle
-import androidx.media3.common.Player
-import androidx.media3.session.CommandButton
-import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaSessionService
-import androidx.media3.session.SessionCommand
-import androidx.media3.session.SessionResult
-import com.google.common.collect.ImmutableList
-import com.google.common.util.concurrent.Futures
-import com.google.common.util.concurrent.ListenableFuture
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
 
 /**
- * MediaSessionService for native video player
- * Provides automatic media notification controls with play/pause buttons
- * Based on: https://developer.android.com/media/implement/surfaces/mobile
+ * Foreground service that backs background video playback.
  *
- * IMPORTANT: MediaSessionService automatically creates and manages the notification
- * when there's an active MediaSession and the system calls onGetSession()
- * The notification appears automatically when media is playing
+ * Streaming (live + VOD) needs the app to keep network access while the screen
+ * is off. A plain posted notification does NOT grant that — only a *running
+ * foreground service* exempts the app from Android's Doze / app-standby
+ * background-network restrictions. Without it the OS cuts the app's network
+ * after a few minutes in the background and ExoPlayer fails with
+ * `UnknownHostException (no network)`.
+ *
+ * The service runs (showing the media notification) only while the player is
+ * actually playing, and is stopped on pause/stop. [VideoPlayerNotificationHandler]
+ * drives [start]/[stop]; the notification itself is built there so its
+ * appearance is unchanged.
+ *
+ * NOTE: this was previously a (never-started, never-given-a-session) Media3
+ * MediaSessionService. It is now a plain foreground Service. The lock-screen
+ * MediaSession lives independently in [VideoPlayerNotificationHandler].
  */
-class VideoPlayerMediaSessionService : MediaSessionService() {
+class VideoPlayerMediaSessionService : Service() {
 
     companion object {
         private const val TAG = "VideoPlayerMSS"
 
-        // The MediaSession is stored here so it can be accessed by the service
-        private var mediaSession: MediaSession? = null
+        // Must match VideoPlayerNotificationHandler.NOTIFICATION_ID so the
+        // foreground notification and the handler's notify()/cancel() updates
+        // operate on a single notification entry.
+        const val NOTIFICATION_ID = 1001
+
+        // The notification to promote to foreground with. Set just before the
+        // service is started; same process, so a static handoff is safe.
+        @Volatile
+        private var pendingNotification: Notification? = null
+
+        // false on pause (detach: keep the notification so the user can resume);
+        // true on stop/idle/dispose (remove it).
+        @Volatile
+        private var removeNotificationOnStop: Boolean = true
+
+        @Volatile
+        private var isRunning: Boolean = false
 
         /**
-         * Gets the current media session
+         * Promotes playback to a foreground service showing [notification].
+         * Safe to call repeatedly: while already running it just refreshes the
+         * notification (e.g. when artwork finishes loading) instead of re-issuing
+         * startForegroundService — which Android 12+ forbids from the background.
          */
-        fun getMediaSession(): MediaSession? = mediaSession
+        fun start(context: Context, notification: Notification) {
+            pendingNotification = notification
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (isRunning) {
+                nm.notify(NOTIFICATION_ID, notification)
+                return
+            }
+            val intent = Intent(context, VideoPlayerMediaSessionService::class.java)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                // Android 12+ throws ForegroundServiceStartNotAllowedException if
+                // play is triggered while the app is in the background (e.g. a
+                // programmatic resume or PiP transition). Fall back to a plain
+                // posted notification so we never crash — background network may
+                // still be limited until the next foreground play, but playback
+                // that is already running keeps its notification.
+                NpLog.w(TAG, "FGS start refused (${e.javaClass.simpleName}); posting notification only")
+                nm.notify(NOTIFICATION_ID, notification)
+            }
+        }
 
         /**
-         * Sets the media session (called by VideoPlayerNotificationHandler)
-         * This must be called before starting the service
+         * Stops the foreground service. [removeNotification] = false detaches the
+         * notification (keeps it visible, for resume on pause); true removes it.
          */
-        fun setMediaSession(session: MediaSession?) {
-            NpLog.d(TAG, "MediaSession ${if (session != null) "set" else "cleared"}, hasPlayer=${session?.player != null}")
-            mediaSession = session
+        fun stop(context: Context, removeNotification: Boolean) {
+            removeNotificationOnStop = removeNotification
+            context.stopService(Intent(context, VideoPlayerMediaSessionService::class.java))
         }
     }
 
-    override fun onCreate() {
-        super.onCreate()
-        NpLog.d(TAG, "VideoPlayerMediaSessionService onCreate, mediaSession=${mediaSession != null}")
-    }
+    override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        NpLog.d(TAG, "onStartCommand called, mediaSession=${mediaSession != null}, player=${mediaSession?.player != null}")
-
-        // Important: Call super to trigger the Media3 notification framework
-        val result = super.onStartCommand(intent, flags, startId)
-
-        // Log player state for debugging
-        mediaSession?.player?.let { player ->
-            NpLog.d(TAG, "Player state: playWhenReady=${player.playWhenReady}, playbackState=${player.playbackState}, mediaItemCount=${player.mediaItemCount}")
-        }
-
-        return result
-    }
-
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
-        NpLog.d(TAG, "onGetSession called for ${controllerInfo.packageName}, returning session=${mediaSession != null}")
-
-        // Return the MediaSession - this triggers the notification to appear
-        return mediaSession
-    }
-
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        NpLog.d(TAG, "Task removed")
-        val session = mediaSession
-        if (session != null) {
-            if (!session.player.playWhenReady || session.player.mediaItemCount == 0) {
-                // Stop the service if not playing
-                NpLog.d(TAG, "Stopping service - not playing")
-                stopSelf()
-            }
-        } else {
+        val notification = pendingNotification
+        if (notification == null) {
+            // No notification to show — must not leave a started service that
+            // never calls startForeground (crashes on O+). Bail cleanly.
+            NpLog.w(TAG, "onStartCommand with no pending notification; stopping")
             stopSelf()
+            return START_NOT_STICKY
         }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+        isRunning = true
+        NpLog.d(TAG, "Foreground service started (playback)")
+        // Not sticky: a system-killed service should not auto-restart with a
+        // stale notification; playback recreation is driven from Dart.
+        return START_NOT_STICKY
     }
 
     override fun onDestroy() {
-        NpLog.d(TAG, "VideoPlayerMediaSessionService onDestroy")
-        // Don't release the player or session here - they're managed by the notification handler
+        val flags = if (removeNotificationOnStop) {
+            Service.STOP_FOREGROUND_REMOVE
+        } else {
+            Service.STOP_FOREGROUND_DETACH
+        }
+        stopForeground(flags)
+        isRunning = false
+        NpLog.d(TAG, "Foreground service stopped (removeNotification=$removeNotificationOnStop)")
         super.onDestroy()
     }
 }

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/handlers/VideoPlayerMethodHandler.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/handlers/VideoPlayerMethodHandler.kt
@@ -720,6 +720,17 @@ class VideoPlayerMethodHandler(
         result.success(null)
     }
 
+    /**
+     * Pins or releases the HLS video quality.
+     *
+     * Crucially this does NOT reload a variant playlist. Each QualityLevel.url
+     * is a single video-only variant; on adaptive HLS the audio lives in a
+     * separate `#EXT-X-MEDIA:TYPE=AUDIO` rendition referenced only by the
+     * master. Calling setMediaSource(HlsMediaSource(variantUrl)) therefore
+     * dropped the audio. Instead we keep the master source loaded and constrain
+     * the *video* track via trackSelectionParameters — audio is untouched and
+     * the switch is instant (no buffering reload).
+     */
     private fun handleSetQuality(call: MethodCall, result: MethodChannel.Result) {
         // Check if current video is HLS before attempting quality switch
         if (!currentVideoIsHls) {
@@ -739,104 +750,46 @@ class VideoPlayerMethodHandler(
         isAutoQuality = isAuto
 
         if (isAuto) {
-            // Start with the middle quality for auto mode
-            val midIndex = (availableQualities.size / 2 - 1).coerceAtLeast(0)
-            if (midIndex >= availableQualities.size) {
-                result.error("NO_QUALITIES", "No qualities available", null)
-                return
-            }
-
-            val initialQuality = availableQualities[midIndex]
-            switchToQuality(initialQuality, result)
-
-            // Start monitoring quality
-            startQualityMonitoring()
-        } else {
-            val url = qualityInfo["url"] as? String
-            val label = qualityInfo["label"] as? String
-
-            if (url == null) {
-                result.error("INVALID_QUALITY", "Quality URL is required", null)
-                return
-            }
-
-            eventHandler.sendEvent("loading")
-
-            // Save current state
-            val wasPlaying = player.isPlaying
-            val currentPosition = player.currentPosition
-
-            // Build new media source
-            // Use DefaultDataSource for consistency with load method (cache
-            // wrap so variant revisits hit the disk cache; never DRM here)
-            val dataSourceFactory =
-                maybeWrapWithCache(DefaultDataSource.Factory(context), url, hasDrm = false)
-            val mediaItem = MediaItem.fromUri(url)
-            val mediaSource = HlsMediaSource.Factory(dataSourceFactory)
-                .createMediaSource(mediaItem)
-
-            // Switch to new quality
-            player.setMediaSource(mediaSource)
-            player.prepare()
-            player.seekTo(currentPosition)
-
-            // Only resume playback if it was playing before
-            if (wasPlaying) {
-                player.play()
-            }
+            // Lift the manual ceiling so ABR resumes. Use MAX rather than
+            // clearVideoSizeConstraints() — the latter would also wipe the
+            // separate viewport cap (setViewportSize) applied by
+            // PlayerBackendSession, which is an independent constraint.
+            player.trackSelectionParameters = player.trackSelectionParameters
+                .buildUpon()
+                .setMaxVideoSize(Int.MAX_VALUE, Int.MAX_VALUE)
+                .setMaxVideoBitrate(Int.MAX_VALUE)
+                .build()
 
             eventHandler.sendEvent("qualityChange", mapOf(
-                "url" to url,
-                "label" to (label ?: ""),
+                "url" to (qualityInfo["url"] as? String ?: ""),
+                "label" to (qualityInfo["label"] as? String ?: "Auto"),
+                "isAuto" to true
+            ))
+            result.success(null)
+        } else {
+            val width = (qualityInfo["width"] as? Number)?.toInt()
+            val height = (qualityInfo["height"] as? Number)?.toInt()
+            val bitrate = (qualityInfo["bitrate"] as? Number)?.toInt()
+
+            player.trackSelectionParameters = player.trackSelectionParameters
+                .buildUpon()
+                .apply {
+                    if (width != null && height != null && width > 0 && height > 0) {
+                        setMaxVideoSize(width, height)
+                    }
+                    if (bitrate != null && bitrate > 0) {
+                        setMaxVideoBitrate(bitrate)
+                    }
+                }
+                .build()
+
+            eventHandler.sendEvent("qualityChange", mapOf(
+                "url" to (qualityInfo["url"] as? String ?: ""),
+                "label" to (qualityInfo["label"] as? String ?: ""),
                 "isAuto" to false
             ))
-
             result.success(null)
         }
-    }
-
-    private fun startQualityMonitoring() {
-        // Quality monitoring is simplified for now
-        // In a production app, you would implement bandwidth monitoring here
-        NpLog.d(TAG, "Auto quality monitoring enabled (simplified implementation)")
-    }
-
-    private fun switchToQuality(quality: Map<String, Any>, result: MethodChannel.Result?) {
-        val url = quality["url"] as? String ?: return
-        val label = quality["label"] as? String ?: "Unknown"
-
-        eventHandler.sendEvent("loading")
-
-        // Save current state
-        val wasPlaying = player.isPlaying
-        val currentPosition = player.currentPosition
-
-        // Build new media source
-        // Use DefaultDataSource for consistency with load method (cache wrap
-        // so variant revisits hit the disk cache; never DRM here)
-        val dataSourceFactory =
-            maybeWrapWithCache(DefaultDataSource.Factory(context), url, hasDrm = false)
-        val mediaItem = MediaItem.fromUri(url)
-        val mediaSource = HlsMediaSource.Factory(dataSourceFactory)
-            .createMediaSource(mediaItem)
-
-        // Switch to new quality
-        player.setMediaSource(mediaSource)
-        player.prepare()
-        player.seekTo(currentPosition)
-
-        // Only resume playback if it was playing before
-        if (wasPlaying) {
-            player.play()
-        }
-
-        eventHandler.sendEvent("qualityChange", mapOf(
-            "url" to url,
-            "label" to label,
-            "isAuto" to isAutoQuality
-        ))
-
-        result?.success(null)
     }
 
     /**

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/handlers/VideoPlayerNotificationHandler.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/handlers/VideoPlayerNotificationHandler.kt
@@ -1,6 +1,7 @@
 package com.huddlecommunity.better_native_video_player.handlers
 
 import com.huddlecommunity.better_native_video_player.NpLog
+import com.huddlecommunity.better_native_video_player.VideoPlayerMediaSessionService
 
 import android.app.Notification
 import android.app.NotificationChannel
@@ -62,9 +63,14 @@ class VideoPlayerNotificationHandler(
     private val playerListener = object : Player.Listener {
         override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
             if (playWhenReady) {
+                // showNotification() promotes playback to a foreground service so
+                // the OS keeps the app's network alive for background streaming.
                 showNotification()
                 eventHandler.sendEvent("play")
             } else {
+                // Pause: drop foreground status (we're no longer streaming) but
+                // keep the notification posted so the user can resume.
+                VideoPlayerMediaSessionService.stop(context, removeNotification = false)
                 updateNotification()
                 eventHandler.sendEvent("pause")
             }
@@ -72,7 +78,10 @@ class VideoPlayerNotificationHandler(
 
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
-                Player.STATE_ENDED, Player.STATE_IDLE -> hideNotification()
+                Player.STATE_ENDED, Player.STATE_IDLE -> {
+                    VideoPlayerMediaSessionService.stop(context, removeNotification = true)
+                    hideNotification()
+                }
                 Player.STATE_READY -> if (player.playWhenReady) showNotification()
             }
         }
@@ -226,8 +235,16 @@ class VideoPlayerNotificationHandler(
     private fun showNotification() {
         try {
             val notification = buildNotification()
-            notificationManager.notify(NOTIFICATION_ID, notification)
-            NpLog.d(TAG, "Notification shown/updated")
+            if (player.playWhenReady) {
+                // While playing, the notification must back a foreground service
+                // so the OS keeps network access for background streaming. The
+                // service refreshes the same NOTIFICATION_ID, so appearance and
+                // later notify()-based updates (artwork) are unchanged.
+                VideoPlayerMediaSessionService.start(context, notification)
+            } else {
+                notificationManager.notify(NOTIFICATION_ID, notification)
+            }
+            NpLog.d(TAG, "Notification shown/updated (playing=${player.playWhenReady})")
         } catch (e: Exception) {
             NpLog.e(TAG, "Error showing notification: ${e.message}", e)
         }
@@ -409,6 +426,7 @@ class VideoPlayerNotificationHandler(
     fun release() {
         stopPositionUpdates()
         player.removeListener(playerListener)
+        VideoPlayerMediaSessionService.stop(context, removeNotification = true)
         hideNotification()
 
         mediaSession?.release()

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/manager/SharedPlayerManager.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/manager/SharedPlayerManager.kt
@@ -3,7 +3,6 @@ package com.huddlecommunity.better_native_video_player.manager
 import com.huddlecommunity.better_native_video_player.NpLog
 
 import android.content.Context
-import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import androidx.media3.common.AudioAttributes
@@ -83,6 +82,14 @@ object SharedPlayerManager {
     ): ExoPlayer {
         val builder = ExoPlayer.Builder(context)
             .setAudioAttributes(AudioAttributes.DEFAULT, false)
+            // Keep the device awake for background playback. WAKE_MODE_NETWORK
+            // holds a partial WakeLock AND a WifiLock so the CPU and WiFi radio
+            // stay powered while playing — without it, screen-off WiFi
+            // power-save/Doze powers the radio down and streaming (live + VOD)
+            // stalls once the buffer drains. ExoPlayer only holds the locks
+            // while actually playing and releases them on pause/stop, so there
+            // is no battery cost when idle. Requires android.permission.WAKE_LOCK.
+            .setWakeMode(C.WAKE_MODE_NETWORK)
         if (prioritizeActivePlayback) {
             builder.setPriorityTaskManager(sharedPriorityTaskManager)
             // Start demoted: loading-while-paused yields to playing players.
@@ -278,11 +285,9 @@ object SharedPlayerManager {
     }
 
     /**
-     * Stops the MediaSessionService
+     * Stops the playback foreground service and removes its notification.
      */
     private fun stopMediaSessionService(context: Context) {
-        VideoPlayerMediaSessionService.setMediaSession(null)
-        val serviceIntent = Intent(context, VideoPlayerMediaSessionService::class.java)
-        context.stopService(serviceIntent)
+        VideoPlayerMediaSessionService.stop(context, removeNotification = true)
     }
 }

--- a/ios/Classes/Handlers/VideoPlayerMethodHandler+Load.swift
+++ b/ios/Classes/Handlers/VideoPlayerMethodHandler+Load.swift
@@ -26,6 +26,10 @@ extension VideoPlayerView {
         let drmConfig = arguments["drmConfig"] as? [String: Any]
         let startAtMs = arguments["startAtMs"] as? Int ?? 0
 
+        // New media starts in Auto: clear any manual-quality pin so the
+        // viewport cap (if configured) applies again.
+        manualQualitySelected = false
+
         // Store media info for Now Playing
         if let mediaInfo = mediaInfo {
             currentMediaInfo = mediaInfo

--- a/ios/Classes/Handlers/VideoPlayerMethodHandler+Quality.swift
+++ b/ios/Classes/Handlers/VideoPlayerMethodHandler+Quality.swift
@@ -8,144 +8,68 @@ import MediaPlayer
 // Split from VideoPlayerMethodHandler.swift for maintainability;
 // all members keep full access to VideoPlayerView state.
 extension VideoPlayerView {
+    /// Pins or releases the HLS video quality.
+    ///
+    /// Crucially this does NOT reload a variant playlist. Each QualityLevel.url
+    /// is a single video-only variant; on adaptive HLS the audio lives in a
+    /// separate `#EXT-X-MEDIA:TYPE=AUDIO` rendition referenced only by the
+    /// master. Replacing the current item with a variant URL therefore dropped
+    /// the audio. Instead we keep the master item loaded and constrain the
+    /// *video* track via `preferredMaximumResolution` / `preferredPeakBitRate`
+    /// — audio is untouched and the switch is instant (no buffering reload).
     func handleSetQuality(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? [String: Any],
               let qualityInfo = args["quality"] as? [String: Any] else {
             result(FlutterError(code: "INVALID_QUALITY", message: "Invalid quality data", details: nil))
             return
         }
-        
+
         let isAuto = qualityInfo["isAuto"] as? Bool ?? false
         isAutoQuality = isAuto
-        
+
         if isAuto {
-            // Start with the middle quality for auto mode
-            let midIndex = max(0, qualityLevels.count / 2 - 1)
-            guard midIndex < qualityLevels.count else {
-                result(FlutterError(code: "NO_QUALITIES", message: "No qualities available", details: nil))
-                return
+            // Lift the manual bitrate ceiling so AVPlayer's native ABR picks
+            // freely. For the resolution ceiling, restore the viewport cap if
+            // it's configured and currently appropriate; otherwise remove it.
+            manualQualitySelected = false
+            player?.currentItem?.preferredPeakBitRate = 0
+            if qualityForViewport, let cap = viewportCapSize,
+               fullscreenPlayerViewController == nil,
+               !(player?.isExternalPlaybackActive ?? false) {
+                player?.currentItem?.preferredMaximumResolution = cap
+            } else {
+                player?.currentItem?.preferredMaximumResolution = .zero
             }
-            
-            let initialQuality = qualityLevels[midIndex]
-            switchToQuality(initialQuality, result: result)
-            
-            // Enable quality monitoring
-            startQualityMonitoring()
-        } else {
-            guard let urlString = qualityInfo["url"] as? String,
-                  let url = URL(string: urlString) else {
-                result(FlutterError(code: "INVALID_URL", message: "Invalid quality URL", details: nil))
-                return
-            }
-            
-            sendEvent("loading")
-            
-            // Store current playback state and position
-            let wasPlaying = player?.rate != 0
-            let currentTime = player?.currentTime() ?? CMTime.zero
-            
-            let newItem = AVPlayerItem(url: url)
-            player?.replaceCurrentItem(with: newItem)
-            player?.seek(to: currentTime)
-            
-            // Only resume playback if it was playing before
-            if wasPlaying {
-                player?.play()
-            }
-            
+
             sendEvent("qualityChange", data: [
-                "url": urlString,
+                "url": qualityInfo["url"] as? String ?? "",
+                "label": qualityInfo["label"] as? String ?? "Auto",
+                "isAuto": true
+            ])
+            result(nil)
+        } else {
+            // Pin to the selected variant by capping the video track. Exact
+            // pinning isn't guaranteed (ABR may still drop lower under
+            // bandwidth pressure) — standard AVPlayer quality-capping behaviour.
+            let width = qualityInfo["width"] as? Int ?? 0
+            let height = qualityInfo["height"] as? Int ?? 0
+            let bitrate = qualityInfo["bitrate"] as? Int ?? 0
+
+            manualQualitySelected = true
+            if width > 0 && height > 0 {
+                player?.currentItem?.preferredMaximumResolution = CGSize(width: width, height: height)
+            }
+            if bitrate > 0 {
+                player?.currentItem?.preferredPeakBitRate = Double(bitrate)
+            }
+
+            sendEvent("qualityChange", data: [
+                "url": qualityInfo["url"] as? String ?? "",
                 "label": qualityInfo["label"] as? String ?? "",
                 "isAuto": false
             ])
             result(nil)
         }
-    }
-
-    func startQualityMonitoring() {
-        // Remove existing observer if any
-        if let timeObserver = timeObserver {
-            player?.removeTimeObserver(timeObserver)
-        }
-        
-        // Monitor playback every second for auto-quality
-        let interval = CMTime(seconds: 1.0, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        timeObserver = player?.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] _ in
-            self?.checkAndAdjustQuality()
-        }
-    }
-
-    func checkAndAdjustQuality() {
-        guard isAutoQuality,
-              !qualityLevels.isEmpty,
-              CACurrentMediaTime() - lastBitrateCheck >= bitrateCheckInterval else {
-            return
-        }
-        
-        lastBitrateCheck = CACurrentMediaTime()
-        
-        // Get current playback statistics
-        let loadedTimeRanges = player?.currentItem?.loadedTimeRanges ?? []
-        let currentTime = player?.currentTime() ?? CMTime.zero
-        
-        // Calculate buffer health
-        var bufferHealth: TimeInterval = 0
-        for range in loadedTimeRanges {
-            let timeRange = range.timeRangeValue
-            if timeRange.start <= currentTime {
-                bufferHealth += timeRange.duration.seconds
-            }
-        }
-        
-        // Get current quality index
-        guard let urlAsset = player?.currentItem?.asset as? AVURLAsset,
-              let currentUrl = urlAsset.url.absoluteString as String?,
-              let currentIndex = qualityLevels.firstIndex(where: { $0.url == currentUrl }) else {
-            return
-        }
-        
-        // Adjust quality based on buffer health
-        var targetIndex = currentIndex
-        
-        if bufferHealth < 3.0 && currentIndex > 0 {
-            // Buffer is low, decrease quality
-            targetIndex = currentIndex - 1
-        } else if bufferHealth > 10.0 && currentIndex < qualityLevels.count - 1 {
-            // Buffer is healthy, try increasing quality
-            targetIndex = currentIndex + 1
-        }
-        
-        if targetIndex != currentIndex {
-            switchToQuality(qualityLevels[targetIndex], result: nil)
-        }
-    }
-
-    func switchToQuality(_ quality: VideoPlayer.QualityLevel, result: FlutterResult?) {
-        guard let url = URL(string: quality.url) else {
-            result?(FlutterError(code: "INVALID_URL", message: "Invalid quality URL", details: nil))
-            return
-        }
-        
-        sendEvent("loading")
-        
-        let wasPlaying = player?.rate != 0
-        let currentTime = player?.currentTime() ?? CMTime.zero
-        
-        let newItem = AVPlayerItem(url: url)
-        player?.replaceCurrentItem(with: newItem)
-        player?.seek(to: currentTime)
-        
-        if wasPlaying {
-            player?.play()
-        }
-        
-        sendEvent("qualityChange", data: [
-            "url": quality.url,
-            "label": quality.label,
-            "isAuto": isAutoQuality
-        ])
-        
-        result?(nil)
     }
 
     /// Stores the platform view's physical pixel size and caps HLS variant
@@ -188,10 +112,13 @@ extension VideoPlayerView {
     /// or AirPlay external playback (which render beyond the inline view's
     /// size) is active. preferredMaximumResolution is a preference: AVPlayer
     /// still plays the lowest variant if none fits, so this can never stall
-    /// playback. Manual quality selection loads a dedicated variant URL via a
-    /// NEW player item and is therefore never constrained by this.
+    /// playback. An explicit manual quality selection (which sets its own
+    /// resolution ceiling) takes precedence — the automatic cap must not
+    /// silently overwrite it on a viewport resize / fullscreen exit / AirPlay
+    /// end; switching back to Auto re-enables this path.
     func applyViewportCapIfAppropriate() {
         guard qualityForViewport, let size = viewportCapSize else { return }
+        guard !manualQualitySelected else { return }
         guard fullscreenPlayerViewController == nil else { return }
         guard !(player?.isExternalPlaybackActive ?? false) else { return }
         npLog("🎚️ Applying viewport quality cap: \(Int(size.width))x\(Int(size.height))")

--- a/ios/Classes/View/VideoPlayerView.swift
+++ b/ios/Classes/View/VideoPlayerView.swift
@@ -71,8 +71,12 @@ import QuartzCore
     var availableQualities: [[String: Any]] = []
     var qualityLevels: [VideoPlayer.QualityLevel] = []
     var isAutoQuality = false
-    var lastBitrateCheck: TimeInterval = 0
-    let bitrateCheckInterval: TimeInterval = 5.0 // Check every 5 seconds
+    /// True while the user has pinned a specific resolution via setQuality.
+    /// Suppresses the automatic viewport cap (see applyViewportCapIfAppropriate)
+    /// so an explicit manual selection isn't silently overwritten on a viewport
+    /// resize / fullscreen exit / AirPlay end. Reset on load and when switching
+    /// back to Auto.
+    var manualQualitySelected = false
     var controllerId: Int?
     var pipController: AVPictureInPictureController?
 

--- a/lib/src/controllers/native_video_player_controller_events.dart
+++ b/lib/src/controllers/native_video_player_controller_events.dart
@@ -469,12 +469,22 @@ extension _ControllerEventPlumbing on NativeVideoPlayerController {
 
               // Handle quality change events
               if (controlEvent.state == PlayerControlState.qualityChanged) {
-                if (controlEvent.data != null &&
-                    controlEvent.data!['quality'] != null) {
-                  final qualityMap = controlEvent.data!['quality'] as Map;
-                  final quality = NativeVideoPlayerQuality.fromMap(qualityMap);
-                  if (!_qualityChangedController.isClosed) {
-                    _qualityChangedController.add(quality);
+                final data = controlEvent.data;
+                if (data != null) {
+                  // Native emits the selected quality's fields flat in the event
+                  // map (url/label/isAuto); the controller's synthetic control
+                  // events nest them under 'quality'. Support both so the
+                  // selected quality reaches qualityChangedStream.
+                  final qualityMap =
+                      (data['quality'] as Map?) ??
+                      ((data['url'] != null || data['label'] != null)
+                          ? data
+                          : null);
+                  if (qualityMap != null &&
+                      !_qualityChangedController.isClosed) {
+                    _qualityChangedController.add(
+                      NativeVideoPlayerQuality.fromMap(qualityMap),
+                    );
                   }
                 }
               }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_native_video_player
-description: Native video player using AVPlayerViewController (iOS) and ExoPlayer (Android) with HLS, Picture-in-Picture, AirPlay, and fullscreen support.
-version: 1.2.1
+description: Native video player (AVPlayer on iOS, ExoPlayer on Android) with HLS, DRM, Chromecast & AirPlay casting, Picture-in-Picture, background playback, and fullscreen.
+version: 1.3.0
 homepage: https://github.com/DaniKemper010/native-video-player
 repository: https://github.com/DaniKemper010/native-video-player.git
 issue_tracker: https://github.com/DaniKemper010/native-video-player/issues

--- a/test/native_video_player_test.dart
+++ b/test/native_video_player_test.dart
@@ -20,10 +20,16 @@ void main() {
 
   late NativeVideoPlayerController controller;
 
+  /// Records every command sent over the shared MethodChannel so tests can
+  /// assert the Dart→native wire contract (e.g. that setQuality forwards
+  /// width/height/bitrate, which the native quality-capping fix relies on).
+  final List<MethodCall> methodCalls = <MethodCall>[];
+
   void installMocks() {
     messenger.setMockMethodCallHandler(methodChannel, (
       MethodCall methodCall,
     ) async {
+      methodCalls.add(methodCall);
       switch (methodCall.method) {
         case 'getAvailableQualities':
           return [
@@ -56,6 +62,7 @@ void main() {
   }
 
   setUp(() {
+    methodCalls.clear();
     installMocks();
     controller = NativeVideoPlayerController(
       id: controllerId,
@@ -143,6 +150,45 @@ void main() {
       final quality = controller.qualities.first;
       await controller.setQuality(quality);
     });
+
+    testWidgets('setQuality forwards width/height/bitrate to native', (
+      tester,
+    ) async {
+      // The native quality fix caps the video track using these fields
+      // (preferredMaximumResolution / setMaxVideoSize + bitrate), so they
+      // MUST reach native. Resolution-style labels ("1920x1080") are what the
+      // native HLS parsers emit, and fromMap parses width/height from them.
+      await attachPlatformView(tester);
+      await controller.load(url: 'https://example.com/video.m3u8');
+
+      final quality = NativeVideoPlayerQuality.fromMap(<String, dynamic>{
+        'label': '1920x1080',
+        'url': 'https://example.com/video_1080p.m3u8',
+        'bitrate': 5000000,
+        'isAuto': false,
+      });
+      await controller.setQuality(quality);
+
+      final setCall = methodCalls.lastWhere((c) => c.method == 'setQuality');
+      final sent = (setCall.arguments as Map)['quality'] as Map;
+      expect(sent['width'], equals(1920));
+      expect(sent['height'], equals(1080));
+      expect(sent['bitrate'], equals(5000000));
+      expect(sent['isAuto'], isFalse);
+    });
+
+    testWidgets('setQuality(auto) forwards isAuto:true to native', (
+      tester,
+    ) async {
+      await attachPlatformView(tester);
+      await controller.load(url: 'https://example.com/video.m3u8');
+
+      await controller.setQuality(NativeVideoPlayerQuality.auto());
+
+      final setCall = methodCalls.lastWhere((c) => c.method == 'setQuality');
+      final sent = (setCall.arguments as Map)['quality'] as Map;
+      expect(sent['isAuto'], isTrue);
+    });
   });
 
   group('NativeVideoPlayerController fullscreen control', () {
@@ -187,6 +233,125 @@ void main() {
 
       expect(receivedEvents.length, equals(1));
       expect(receivedEvents.first.state, equals(PlayerActivityState.playing));
+    });
+
+    testWidgets(
+      'emits selected quality from a flat native qualityChange event',
+      (tester) async {
+        await attachPlatformView(tester);
+
+        // Native sends the selected quality's fields flat in the event map
+        // (url/label/isAuto) — regression test for qualityChangedStream staying
+        // silent when the handler only accepted a nested 'quality' key.
+        final next = controller.qualityChangedStream.first.timeout(
+          const Duration(seconds: 3),
+        );
+
+        await messenger.handlePlatformMessage(
+          'native_video_player_$platformViewId',
+          const StandardMethodCodec().encodeSuccessEnvelope({
+            'event': 'qualityChange',
+            'url': 'https://example.com/video_720p.m3u8',
+            'label': '720p',
+            'isAuto': false,
+          }),
+          (ByteData? data) {},
+        );
+        await tester.pump();
+
+        final quality = await next;
+        expect(quality.label, equals('720p'));
+        expect(quality.isAuto, isFalse);
+      },
+    );
+
+    testWidgets('emits Auto from a flat native qualityChange event', (
+      tester,
+    ) async {
+      await attachPlatformView(tester);
+
+      final next = controller.qualityChangedStream.first.timeout(
+        const Duration(seconds: 3),
+      );
+
+      await messenger.handlePlatformMessage(
+        'native_video_player_$platformViewId',
+        const StandardMethodCodec().encodeSuccessEnvelope({
+          'event': 'qualityChange',
+          'url': '',
+          'label': 'Auto',
+          'isAuto': true,
+        }),
+        (ByteData? data) {},
+      );
+      await tester.pump();
+
+      final quality = await next;
+      expect(quality.label, equals('Auto'));
+      expect(quality.isAuto, isTrue);
+    });
+
+    testWidgets('emits selected quality from a nested qualityChange event', (
+      tester,
+    ) async {
+      // Backward compatibility: synthetic control events nest the quality under
+      // a 'quality' key. The handler must still accept that shape.
+      await attachPlatformView(tester);
+
+      final next = controller.qualityChangedStream.first.timeout(
+        const Duration(seconds: 3),
+      );
+
+      await messenger.handlePlatformMessage(
+        'native_video_player_$platformViewId',
+        const StandardMethodCodec().encodeSuccessEnvelope({
+          'event': 'qualityChange',
+          'quality': {
+            'url': 'https://example.com/video_1080p.m3u8',
+            'label': '1080p',
+            'isAuto': false,
+          },
+        }),
+        (ByteData? data) {},
+      );
+      await tester.pump();
+
+      final quality = await next;
+      expect(quality.label, equals('1080p'));
+      expect(quality.isAuto, isFalse);
+    });
+  });
+
+  group('NativeVideoPlayerQuality model', () {
+    test('fromMap parses width/height from a resolution label', () {
+      final q = NativeVideoPlayerQuality.fromMap(<String, dynamic>{
+        'label': '1920x1080',
+        'url': 'https://example.com/1080p.m3u8',
+        'bitrate': 5000000,
+        'isAuto': false,
+      });
+      expect(q.width, equals(1920));
+      expect(q.height, equals(1080));
+      expect(q.bitrate, equals(5000000));
+      expect(q.isAuto, isFalse);
+    });
+
+    test('toMap carries the fields the native quality cap reads', () {
+      final map = const NativeVideoPlayerQuality(
+        label: '1280x720',
+        url: 'https://example.com/720p.m3u8',
+        bitrate: 2500000,
+        width: 1280,
+        height: 720,
+      ).toMap();
+      expect(map['width'], equals(1280));
+      expect(map['height'], equals(720));
+      expect(map['bitrate'], equals(2500000));
+      expect(map['isAuto'], isFalse);
+    });
+
+    test('auto() is flagged isAuto', () {
+      expect(NativeVideoPlayerQuality.auto().isAuto, isTrue);
     });
   });
 }


### PR DESCRIPTION
Fixes #38, #39, #40 and ships as **v1.3.0**.

## Fixes

- **#40 — Quality switch dropped audio (iOS + Android).** Selecting an HLS quality (or switching back to Auto) reloaded a single video-only variant playlist, replacing the master. On adaptive streams that carry audio as a separate `#EXT-X-MEDIA:TYPE=AUDIO` rendition, that silenced the audio. Now the master stays loaded and the **video track** is constrained via the player's track selector (`preferredMaximumResolution`/`preferredPeakBitRate` on iOS, `setMaxVideoSize`/`setMaxVideoBitrate` on Android) — audio intact, switch is instant. Removed the dead auto-reload helpers (also fixes the iOS shared-`timeObserver` clobber that stopped position updates when Auto was enabled).
- **#39 — `qualityChangedStream` never emitted.** Native sends the quality fields flat in the event map; the Dart handler only accepted a nested `quality` key. Now accepts both shapes (backward compatible).
- **#38 — Android background playback died after a few minutes.** A media notification was posted but no real foreground service ran, so Doze/App-Standby cut the app's network and ExoPlayer failed with `UnknownHostException`. Playback now runs as a real foreground `Service` while playing (stopped on pause/stop), with `setWakeMode(WAKE_MODE_NETWORK)` and the `WAKE_LOCK` permission.

## Tests / gates

- Dart: 19 tests pass (event routing for #39, `setQuality` wire contract for #40, model serialization), `flutter analyze` clean.
- Android: `:better_native_video_player:compileDebugKotlin` BUILD SUCCESSFUL.
- iOS: simulator build succeeded.
- Native runtime behavior (audio surviving a switch, background streaming surviving screen-off) requires on-device verification — checklist in the release.

Also updates the pubspec `description` (DRM, Chromecast & AirPlay casting, background playback; 174 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmVE6DkzkxsKEK3qPxFS2F