### PR TITLE
fix: start LIVE casts at the live edge (#44)

### DIFF
--- a/lib/src/services/cast/cast_session_io.dart
+++ b/lib/src/services/cast/cast_session_io.dart
@@ -313,11 +313,17 @@ class CastSession {
     bool autoplay = true,
     Duration startAt = Duration.zero,
   }) async {
+    // For LIVE streams an explicit currentTime of 0 makes the receiver start at
+    // the beginning of the DVR window; omitting the field lets it default to the
+    // live edge, matching local playback. Only send it when the caller actually
+    // requested a position (or for regular buffered media).
+    final bool sendCurrentTime = streamType != 'LIVE' || startAt > Duration.zero;
+
     final payload = <String, dynamic>{
       'type': 'LOAD',
       'requestId': _nextRequestId(),
       'autoplay': autoplay,
-      'currentTime': startAt.inMilliseconds / 1000,
+      if (sendCurrentTime) 'currentTime': startAt.inMilliseconds / 1000,
       if (activeTrackIds.isNotEmpty) 'activeTrackIds': activeTrackIds,
       'media': <String, dynamic>{
         'contentId': contentUrl,


### PR DESCRIPTION
## Summary
`CastSession.loadMedia` always sent `currentTime` (default 0) in the LOAD request. For live HLS streams with a DVR window, receivers treat that as an absolute position and start minutes behind real time (#44).

## Fix
Omit `currentTime` for `streamType: 'LIVE'` unless the caller explicitly passes a non-zero `startAt`; the receiver then defaults to the live edge, matching local playback. Buffered media unchanged.

## Testing
- Cast a live radio/TV stream with a DVR window → starts at the live edge.
- Cast VOD with `startAt` → still resumes at the requested position.

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChaHRbo9wL24HVFggUyJoA