### PR TITLE
fix: Android auto-PiP leak after fullscreen dismiss + pause when PiP window is closed

### DIFF
--- a/lib/src/controllers/native_video_player_controller.dart
+++ b/lib/src/controllers/native_video_player_controller.dart
@@ -1694,6 +1694,10 @@ class NativeVideoPlayerController {
         final bool inPip = (await _floating.pipStatus) == PiPStatus.enabled;
         if (!_isDisposed && inPip != _state.isPipEnabled) {
           _updateState(_state.copyWith(isPipEnabled: inPip));
+
+          if (!inPip) {
+            unawaited(_pauseIfPipDismissed());
+          }
         }
       });
     } else if (!state.isFullScreen && _androidPipPollTimer != null) {
@@ -1704,6 +1708,24 @@ class NativeVideoPlayerController {
         _updateState(_state.copyWith(isPipEnabled: false));
       }
     }
+  }
+
+  /// Pauses playback when the PiP window was dismissed with its close (X)
+  /// button. Dismissing stops the activity without bringing the app back to
+  /// the foreground, so without this the media session keeps playing audio in
+  /// the background. Expanding the PiP window back into the app resumes the
+  /// activity almost immediately — the delayed lifecycle re-check tells the
+  /// two apart.
+  Future<void> _pauseIfPipDismissed() async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    if (_isDisposed ||
+        WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed) {
+      return;
+    }
+
+    debugPrint('PiP window dismissed while app is backgrounded — pausing');
+    await pause();
   }
 
   /// Maps URL sources for Android's native sideloading; null on other
@@ -2087,6 +2109,16 @@ class NativeVideoPlayerController {
         _dartFullscreenCloseCallback = null;
         if (_state.isFullScreen) {
           _updateState(_state.copyWith(isFullScreen: false));
+
+          // Mirror exitFullScreen(): leaving fullscreen must disarm the
+          // activity-global OnLeavePiP, otherwise auto-PiP stays armed for the
+          // rest of the session and any later app-leave enters PiP — even from
+          // inline playback or with no video playing at all.
+          if (!kIsWeb && Platform.isAndroid) {
+            _floating.cancelOnLeavePiP();
+            debugPrint('Automatic PiP disabled (fullscreen dialog dismissed)');
+            unawaited(_refreshAvailabilityFlags());
+          }
         }
       },
     );


### PR DESCRIPTION
## Summary
Two Android PiP bugs reported against the Huddle app (HAB-837, HAB-838):

1. **Auto-PiP leak:** `enterFullScreen()` arms the activity-global `OnLeavePiP`, and `exitFullScreen()` disarms it — but the Dart fullscreen dialog's `onExit` path (back button / dialog dismissal) only reset `isFullScreen` without disarming. After one fullscreen visit, every later app-leave entered PiP, even from inline playback or with no video playing. Because the state was already false, `exitFullScreen()` early-returned forever, making the leak permanent for the session.
2. **PiP close (X) keeps playing:** dismissing the PiP window stops the activity without resuming the app; nothing paused the player, so the media-session service kept audio running in the background (YouTube/Netflix pause here).

## Fix
- `onExit` now mirrors `exitFullScreen()`: `cancelOnLeavePiP()` + availability refresh on Android.
- The PiP status poll pauses playback when PiP exits while the app is **not** resumed, with a 300 ms lifecycle re-check so expanding the window back into the app keeps playing.

## Testing (Android device)
- Video → fullscreen → back button → home: app must NOT enter PiP.
- Fullscreen → home: PiP starts (intended, unchanged).
- PiP → X: audio stops ≤1 s. PiP → tap window → expand: keeps playing.
- Regression: background audio streamables unaffected (different path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChaHRbo9wL24HVFggUyJoA