### PR TITLE
feat: embedded caption text-size scaling via embeddedTextScale (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-02
+
+### Added
+
+- **Embedded caption text-size scaling** (#43): `NativeVideoPlayerSubtitleStyle.embeddedTextScale`
+  (default `1.0` = platform default) and the convenience method
+  `controller.setNativeSubtitleTextScale(double)` scale the text size of EMBEDDED
+  (native-rendered) subtitle tracks — ExoPlayer's `SubtitleView` on Android (both the
+  lightweight and PlayerView display paths), `AVPlayerItem.textStyleRules` on iOS.
+  Takes effect live without a playback restart, survives quality/audio/variant switches,
+  item reloads, and native view recreation, and scales relative to the user's system
+  caption size preference. Sidecar overlay sizing (`subtitleStyle.fontSize`) is unaffected.
+
 ## [1.3.2] - 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Flutter plugin for native video playback on iOS and Android with advanced feat
 - ✅ Background playback with media notifications
 - ✅ Playback controls: play, pause, seek, volume, speed (0.25x - 2.0x)
 - ✅ Quality selection for HLS streams with real-time switching
-- ✅ **Subtitle/Closed Caption support** for HLS streams (VOD and Live) with language selection
+- ✅ **Subtitle/Closed Caption support** for HLS streams (VOD and Live) with language selection and adjustable embedded-caption text size
 - ✅ **Sidecar subtitles**: load external VTT/SRT files (URL, file, or raw content) with fully styleable, positionable rendering
 - ✅ **Audio track selection**: list and switch alternate audio renditions (languages, audio descriptions)
 - ✅ **Resume positions**: `load(startAt:)` applied natively before the first frame + `PositionCheckpoints` for persistence
@@ -706,6 +706,23 @@ showSubtitlePicker(
 );
 ```
 
+**Scaling Embedded Caption Text Size:**
+
+Embedded tracks are rendered by the platform caption renderers, so `subtitleStyle.fontSize` doesn't affect them. Use the embedded text scale instead — it takes effect live, survives quality switches and item reloads, and scales relative to the user's system caption size preference (`1.0` = platform default):
+
+```dart
+// Convenience method (150% captions)
+await _controller.setNativeSubtitleTextScale(1.5);
+
+// Or drive it through the style object alongside the sidecar styling
+_controller.setSubtitleStyle(
+  const NativeVideoPlayerSubtitleStyle(embeddedTextScale: 1.5),
+);
+
+// Back to the platform default
+await _controller.setNativeSubtitleTextScale(1.0);
+```
+
 **Example HLS Streams with Subtitles:**
 ```dart
 // Apple's example stream with multiple subtitle languages
@@ -721,7 +738,7 @@ final subtitles = await _controller.getAvailableSubtitleTracks();
 - Embedded subtitle tracks are automatically detected from the stream
 - External subtitle files (SRT, VTT) are supported as *sidecar subtitles* — see the next section
 - Both VOD (Video on Demand) and Live streams are supported
-- Font rendering and styling of *embedded* tracks are handled by the native players (AVPlayer on iOS, ExoPlayer on Android); *sidecar* subtitles are rendered by the plugin and fully styleable
+- Font rendering and styling of *embedded* tracks are handled by the native players (AVPlayer on iOS, ExoPlayer on Android) — only the text size can be scaled via `embeddedTextScale` / `setNativeSubtitleTextScale`; *sidecar* subtitles are rendered by the plugin and fully styleable
 
 **Platform-Specific Behavior:**
 - **iOS**: Uses AVFoundation's `AVMediaSelectionGroup` for subtitle track management

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/PlayerBackendSession.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/PlayerBackendSession.kt
@@ -62,6 +62,12 @@ class PlayerBackendSession(
     private var lastViewportWidth: Int = 0
     private var lastViewportHeight: Int = 0
 
+    // Text-size scale for embedded (native-rendered) subtitle tracks; 1.0 =
+    // platform default. Stored here so it survives media-item replacement;
+    // Dart re-sends it when the backend view itself is recreated (issue #43).
+    var embeddedTextScale: Float = 1f
+        private set
+
     init {
         // Extract and store media info from args (if provided during initialization)
         // This ensures we have the correct media info even for shared players
@@ -245,6 +251,12 @@ class PlayerBackendSession(
         if (lastViewportWidth > 0 && lastViewportHeight > 0) {
             applyViewportConstraints(lastViewportWidth, lastViewportHeight)
         }
+    }
+
+    /** Stores the embedded-caption text scale; the backend applies it to its SubtitleView(s). */
+    fun setEmbeddedTextScale(scale: Float) {
+        if (scale <= 0f) return
+        embeddedTextScale = scale
     }
 
     /**

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/TextureVideoPlayer.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/TextureVideoPlayer.kt
@@ -148,6 +148,14 @@ class TextureVideoPlayer(
                 session.setViewportSize(width, height, isFullScreen = false)
                 result.success(null)
             }
+            "setEmbeddedTextScale" -> {
+                // Texture mode has no native SubtitleView (captions render via
+                // the Flutter sidecar overlay); store so a later platform-view
+                // rebind of the shared session picks it up.
+                val scale = (call.argument<Number>("scale"))?.toFloat() ?: 1f
+                session.setEmbeddedTextScale(scale)
+                result.success(null)
+            }
             "enterFullScreen", "exitFullScreen" -> {
                 // No Android View to move into a fullscreen dialog; the Dart
                 // controller falls back to Dart fullscreen for texture views.

--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerView.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerView.kt
@@ -9,6 +9,7 @@ import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.view.accessibility.CaptioningManager
 import android.widget.FrameLayout
 import androidx.annotation.RequiresApi
 import androidx.core.view.WindowCompat
@@ -59,6 +60,7 @@ class VideoPlayerView(
     // SubtitleView wired to the player's cues so captions (including the
     // native sidecar track used during PiP/fullscreen) keep rendering.
     private val lightSurfaceView: SurfaceView?
+    private val lightSubtitleView: SubtitleView?
     private val lightListener: Player.Listener?
 
     // Reports the video's display size to Dart in both display paths so the
@@ -162,11 +164,13 @@ class VideoPlayerView(
             }
             player.addListener(listener)
             lightSurfaceView = surfaceView
+            lightSubtitleView = subtitleView
             lightListener = listener
             videoContentView = contentFrame
             NpLog.d(TAG, "Lightweight SurfaceView configured (controls hidden)")
         } else {
             lightSurfaceView = null
+            lightSubtitleView = null
             lightListener = null
             playerView = PlayerView(context).apply {
                 this.player = this@VideoPlayerView.player
@@ -192,6 +196,8 @@ class VideoPlayerView(
             }
             videoContentView = playerView
         }
+
+        applyEmbeddedTextScale()
 
         // Report the video's display size to Dart so the sidecar subtitle
         // overlay can pin captions to the video's content rect. Covers both
@@ -303,6 +309,12 @@ class VideoPlayerView(
                 val width = (call.argument<Number>("width"))?.toInt() ?: 0
                 val height = (call.argument<Number>("height"))?.toInt() ?: 0
                 session.setViewportSize(width, height, isFullScreen)
+                result.success(null)
+            }
+            "setEmbeddedTextScale" -> {
+                val scale = (call.argument<Number>("scale"))?.toFloat() ?: 1f
+                session.setEmbeddedTextScale(scale)
+                applyEmbeddedTextScale()
                 result.success(null)
             }
             else -> {
@@ -634,6 +646,31 @@ class VideoPlayerView(
     private fun applyLightAspectRatio(frame: AspectRatioFrameLayout, videoSize: VideoSize) {
         if (videoSize.width == 0 || videoSize.height == 0) return
         frame.setAspectRatio(videoSize.width * videoSize.pixelWidthHeightRatio / videoSize.height)
+    }
+
+    /**
+     * Applies the session's embedded-caption text scale to both display
+     * paths' SubtitleViews (issue #43). Scales relative to the user's system
+     * caption preference, so 1.0 keeps the platform-default size — identical
+     * to setUserDefaultTextSize().
+     */
+    private fun applyEmbeddedTextScale() {
+        val scale = session.embeddedTextScale
+        for (subtitleView in listOfNotNull(lightSubtitleView, playerView?.subtitleView)) {
+            if (scale == 1f) {
+                subtitleView.setUserDefaultTextSize()
+            } else {
+                subtitleView.setFractionalTextSize(
+                    SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * userCaptionFontScale() * scale
+                )
+            }
+        }
+    }
+
+    private fun userCaptionFontScale(): Float {
+        val captioningManager =
+            context.getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+        return if (captioningManager?.isEnabled == true) captioningManager.fontScale else 1f
     }
 
     /**

--- a/ios/Classes/Handlers/VideoPlayerMethodHandler+Captions.swift
+++ b/ios/Classes/Handlers/VideoPlayerMethodHandler+Captions.swift
@@ -1,0 +1,46 @@
+import Flutter
+import AVFoundation
+import CoreMedia
+
+// Embedded-caption styling (issue #43): scales the text size of subtitle
+// tracks rendered natively by AVPlayer, via AVPlayerItem.textStyleRules.
+// The item is only ever swapped in handleLoad (quality/audio/subtitle
+// switches mutate the current item), so applying live + on load covers
+// every item.
+extension VideoPlayerView {
+    func handleSetEmbeddedTextScale(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let scale = args["scale"] as? Double,
+              scale > 0 else {
+            result(FlutterError(code: "INVALID_SCALE", message: "Invalid scale value", details: nil))
+            return
+        }
+
+        npLog("Setting embedded caption text scale to: \(scale)")
+        embeddedTextScale = CGFloat(scale)
+        applyEmbeddedTextScale()
+        result(nil)
+    }
+
+    /// Applies [embeddedTextScale] to the current AVPlayerItem. At 1.0 the
+    /// rules are cleared so the user's system caption styling stays intact.
+    func applyEmbeddedTextScale() {
+        guard let playerItem = player?.currentItem else { return }
+
+        if embeddedTextScale == 1.0 {
+            playerItem.textStyleRules = nil
+            return
+        }
+
+        let attributes: [String: Any] = [
+            kCMTextMarkupAttribute_RelativeFontSize as String: embeddedTextScale * 100.0
+        ]
+
+        guard let rule = AVTextStyleRule(textMarkupAttributes: attributes) else {
+            npLog("Failed to build AVTextStyleRule for embedded caption scale \(embeddedTextScale)")
+            return
+        }
+
+        playerItem.textStyleRules = [rule]
+    }
+}

--- a/ios/Classes/Handlers/VideoPlayerMethodHandler+Load.swift
+++ b/ios/Classes/Handlers/VideoPlayerMethodHandler+Load.swift
@@ -164,6 +164,10 @@ extension VideoPlayerView {
         // This allows the video to start loading right away
         player?.replaceCurrentItem(with: playerItem)
 
+        // Re-apply the embedded caption text scale to the fresh item
+        // (textStyleRules live on the AVPlayerItem, not the player)
+        applyEmbeddedTextScale()
+
         // --- Configure HDR settings asynchronously (doesn't block video loading) ---
         // Only apply color space correction if HDR is explicitly disabled AND we detect this might be HDR content
         // For most standard videos, the default handling is fine

--- a/ios/Classes/View/VideoPlayerView.swift
+++ b/ios/Classes/View/VideoPlayerView.swift
@@ -152,6 +152,10 @@ import QuartzCore
     // Store desired playback speed
     var desiredPlaybackSpeed: Float = 1.0
 
+    // Text-size scale for embedded (native-rendered) subtitle tracks;
+    // 1.0 = system default. Re-applied to every new AVPlayerItem (issue #43).
+    var embeddedTextScale: CGFloat = 1.0
+
     // Store HDR setting
     var enableHDR: Bool = false
 
@@ -676,6 +680,8 @@ import QuartzCore
             handleGetAvailableSubtitleTracks(result: result)
         case "setSubtitleTrack":
             handleSetSubtitleTrack(call: call, result: result)
+        case "setEmbeddedTextScale":
+            handleSetEmbeddedTextScale(call: call, result: result)
         case "getAvailableAudioTracks":
             handleGetAvailableAudioTracks(result: result)
         case "setAudioTrack":

--- a/lib/src/controllers/native_video_player_controller.dart
+++ b/lib/src/controllers/native_video_player_controller.dart
@@ -189,6 +189,11 @@ class NativeVideoPlayerController {
   /// host renders captions identically to the inline player.
   NativeVideoPlayerSubtitleStyle? _subtitleStyle;
 
+  /// Text-size scale for embedded (native-rendered) subtitle tracks.
+  /// Cached so it can be re-applied when the native view is recreated
+  /// (list→detail→back) or a new item is loaded. Issue #43.
+  double _embeddedTextScale = 1.0;
+
   /// Callback to close the Dart fullscreen dialog
   /// Set by FullscreenVideoPlayer when it's created
   VoidCallback? _dartFullscreenCloseCallback;
@@ -1030,8 +1035,19 @@ class NativeVideoPlayerController {
   /// Typically called by the NativeVideoPlayer widget so the Dart fullscreen
   /// host (which builds its own NativeVideoPlayer) renders captions with the
   /// same style as the inline player.
+  ///
+  /// [NativeVideoPlayerSubtitleStyle.embeddedTextScale] is additionally
+  /// pushed to the platform caption renderer (fire-and-forget) when it
+  /// changed since the last call.
   void setSubtitleStyle(NativeVideoPlayerSubtitleStyle style) {
     _subtitleStyle = style;
+
+    if (style.embeddedTextScale != _embeddedTextScale) {
+      _embeddedTextScale = style.embeddedTextScale;
+      unawaited(
+        _methodChannel?.setEmbeddedTextScale(style.embeddedTextScale),
+      );
+    }
   }
 
   /// Sets the callback for closing Dart fullscreen
@@ -1071,6 +1087,13 @@ class NativeVideoPlayerController {
       if (_methodChannel != null) {
         await _methodChannel!.ensureSurfaceConnected();
       }
+
+      // Re-apply the embedded caption text scale — the recreated native view
+      // builds its SubtitleView with the platform default size.
+      if (_embeddedTextScale != 1.0 && _methodChannel != null) {
+        await _methodChannel!.setEmbeddedTextScale(_embeddedTextScale);
+      }
+
       // Re-fetch availability flags from native side FIRST (wait for it to complete)
       // This ensures the state is up-to-date before we emit it
       await _refreshAvailabilityFlags();
@@ -1314,6 +1337,11 @@ class NativeVideoPlayerController {
         startAtMs: startAt?.inMilliseconds,
       );
 
+      // Re-apply the embedded caption text scale to the fresh player item.
+      if (_embeddedTextScale != 1.0) {
+        await _methodChannel!.setEmbeddedTextScale(_embeddedTextScale);
+      }
+
       // Fetch available qualities after loading
       final qualities = await _methodChannel!.getAvailableQualities();
 
@@ -1513,6 +1541,18 @@ class NativeVideoPlayerController {
   /// Sets the playback speed
   Future<void> setSpeed(double speed) async {
     await _methodChannel?.setSpeed(speed);
+  }
+
+  /// Scales the text size of EMBEDDED (native-rendered) subtitle tracks.
+  /// 1.0 = platform default. No effect on the sidecar overlay (use
+  /// [setSubtitleStyle] / `subtitleStyle.fontSize` for that). Issue #43.
+  ///
+  /// Takes effect live and survives item reloads and native view recreation.
+  Future<void> setNativeSubtitleTextScale(double scale) async {
+    _embeddedTextScale = scale;
+    _subtitleStyle = (_subtitleStyle ?? const NativeVideoPlayerSubtitleStyle())
+        .copyWith(embeddedTextScale: scale);
+    await _methodChannel?.setEmbeddedTextScale(scale);
   }
 
   /// Sets whether the video should loop

--- a/lib/src/models/native_video_player_subtitle_style.dart
+++ b/lib/src/models/native_video_player_subtitle_style.dart
@@ -4,11 +4,14 @@ import 'package:flutter/widgets.dart';
 /// Flutter overlay (covers the caption customization requested in issue
 /// #29: size, colors, and where on the video the captions sit).
 ///
-/// Applies to sidecar (VTT/SRT) subtitles only; EMBEDDED native subtitle
-/// tracks are rendered by the platform with system caption settings.
+/// Applies to sidecar (VTT/SRT) subtitles only, with one exception:
+/// [embeddedTextScale], which scales EMBEDDED native subtitle tracks
+/// (rendered by the platform caption renderers, issue #43). All other
+/// fields have no effect on embedded tracks.
 ///
 /// To change the style at runtime, rebuild the [NativeVideoPlayer] widget
-/// with a new `subtitleStyle` (the overlay rebuilds immediately).
+/// with a new `subtitleStyle` (the overlay rebuilds immediately;
+/// [embeddedTextScale] is pushed to the platform renderer).
 @immutable
 class NativeVideoPlayerSubtitleStyle {
   const NativeVideoPlayerSubtitleStyle({
@@ -27,6 +30,7 @@ class NativeVideoPlayerSubtitleStyle {
     this.fullscreenLandscapeFontSize,
     this.fullscreenLandscapeFontWeight,
     this.fullscreenLandscapeLineHeight,
+    this.embeddedTextScale = 1.0,
   });
 
   // --- Text ---
@@ -73,6 +77,14 @@ class NativeVideoPlayerSubtitleStyle {
   final FontWeight? fullscreenLandscapeFontWeight;
   final double? fullscreenLandscapeLineHeight;
 
+  // --- Embedded (native-rendered) tracks ---
+
+  /// Text-size scale for EMBEDDED subtitle tracks rendered by the platform
+  /// (ExoPlayer's SubtitleView on Android, AVPlayer captions on iOS).
+  /// 1.0 = platform default (the user's system caption size preference).
+  /// Ignored by the sidecar overlay — use [fontSize] for that.
+  final double embeddedTextScale;
+
   NativeVideoPlayerSubtitleStyle copyWith({
     double? fontSize,
     FontWeight? fontWeight,
@@ -89,6 +101,7 @@ class NativeVideoPlayerSubtitleStyle {
     double? fullscreenLandscapeFontSize,
     FontWeight? fullscreenLandscapeFontWeight,
     double? fullscreenLandscapeLineHeight,
+    double? embeddedTextScale,
   }) {
     return NativeVideoPlayerSubtitleStyle(
       fontSize: fontSize ?? this.fontSize,
@@ -109,6 +122,7 @@ class NativeVideoPlayerSubtitleStyle {
           fullscreenLandscapeFontWeight ?? this.fullscreenLandscapeFontWeight,
       fullscreenLandscapeLineHeight:
           fullscreenLandscapeLineHeight ?? this.fullscreenLandscapeLineHeight,
+      embeddedTextScale: embeddedTextScale ?? this.embeddedTextScale,
     );
   }
 }

--- a/lib/src/platform/video_player_method_channel.dart
+++ b/lib/src/platform/video_player_method_channel.dart
@@ -192,6 +192,20 @@ class VideoPlayerMethodChannel {
     }
   }
 
+  /// Sets the text-size scale for embedded (native-rendered) subtitle
+  /// tracks. 1.0 = platform default. Issue #43.
+  Future<void> setEmbeddedTextScale(double scale) async {
+    try {
+      await _methodChannel
+          .invokeMethod<void>('setEmbeddedTextScale', <String, Object>{
+        'viewId': primaryPlatformViewId,
+        'scale': scale,
+      });
+    } catch (e) {
+      debugPrint('Error calling setEmbeddedTextScale: $e');
+    }
+  }
+
   /// Sets the playback speed
   Future<void> setSpeed(double speed) async {
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_native_video_player
 description: Native video player (AVPlayer on iOS, ExoPlayer on Android) with HLS, DRM, Chromecast & AirPlay casting, Picture-in-Picture, background playback, and fullscreen.
-version: 1.3.2
+version: 1.4.0
 homepage: https://github.com/DaniKemper010/native-video-player
 repository: https://github.com/DaniKemper010/native-video-player.git
 issue_tracker: https://github.com/DaniKemper010/native-video-player/issues

--- a/test/native_video_player_controller_channel_test.dart
+++ b/test/native_video_player_controller_channel_test.dart
@@ -349,6 +349,63 @@ void main() {
     );
   });
 
+  group('embedded caption text scale', () {
+    testWidgets('is sent on change and re-sent when the view is recreated', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const SizedBox());
+      final context = tester.element(find.byType(SizedBox));
+
+      await tester.runAsync(() async {
+        mockMethodChannel();
+        mockControllerStream(15);
+        mockViewStream(501);
+
+        final controller = NativeVideoPlayerController(id: 15);
+        await flushSetup(controller);
+        await controller.onPlatformViewCreated(501, context);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        log.clear();
+        await controller.setNativeSubtitleTextScale(1.5);
+        expect(log, contains('method:setEmbeddedTextScale'));
+
+        // Recreate the native view (list→detail→back): the scale must be
+        // re-applied because the platform renderer was rebuilt with defaults.
+        controller.onPlatformViewDisposed(501);
+        mockViewStream(502);
+        log.clear();
+        await controller.onPlatformViewCreated(502, context);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(log, contains('method:setEmbeddedTextScale'));
+        expect(flutterErrors, isEmpty);
+
+        await controller.dispose();
+      });
+    });
+
+    testWidgets('default scale is not sent on view creation', (tester) async {
+      await tester.pumpWidget(const SizedBox());
+      final context = tester.element(find.byType(SizedBox));
+
+      await tester.runAsync(() async {
+        mockMethodChannel();
+        mockControllerStream(16);
+        mockViewStream(503);
+
+        final controller = NativeVideoPlayerController(id: 16);
+        await flushSetup(controller);
+        await controller.onPlatformViewCreated(503, context);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(log, isNot(contains('method:setEmbeddedTextScale')));
+
+        await controller.dispose();
+      });
+    });
+  });
+
   group('platform view safety net', () {
     testWidgets('onPlatformViewCreated sets up the channel if setup failed', (
       tester,

--- a/test/native_video_player_method_channel_test.dart
+++ b/test/native_video_player_method_channel_test.dart
@@ -26,6 +26,8 @@ void main() {
               return null;
             case 'setSpeed':
               return null;
+            case 'setEmbeddedTextScale':
+              return null;
             case 'setQuality':
               return null;
             case 'getAvailableQualities':
@@ -130,6 +132,26 @@ void main() {
         isA<MethodCall>()
             .having((c) => c.method, 'method', 'setSpeed')
             .having((c) => c.arguments, 'arguments', speed),
+      ),
+    );
+  });
+
+  test('setEmbeddedTextScale method sends correct value', () async {
+    const double scale = 1.5;
+    await channel.invokeMethod<void>('setEmbeddedTextScale', {
+      'viewId': 1,
+      'scale': scale,
+    });
+    expect(
+      methodCalls,
+      contains(
+        isA<MethodCall>()
+            .having((c) => c.method, 'method', 'setEmbeddedTextScale')
+            .having(
+              (c) => c.arguments,
+              'arguments',
+              containsPair('scale', scale),
+            ),
       ),
     );
   });


### PR DESCRIPTION
## Summary

Implements #43: an API to scale the text size of **embedded / native-rendered** subtitle tracks, live-updatable and persistent across item reloads, quality/audio/variant switches, and native view recreation.

- **Dart**: `NativeVideoPlayerSubtitleStyle.embeddedTextScale` (default `1.0` = platform default) driven through the existing `setSubtitleStyle`, plus the convenience `controller.setNativeSubtitleTextScale(double)`. New `setEmbeddedTextScale` method-channel command; the scale is cached on the controller and re-sent after `load` and on view reconnect.
- **Android**: `SubtitleView.setFractionalTextSize(DEFAULT_TEXT_SIZE_FRACTION × userCaptionFontScale × scale)` on **both** display paths (lightweight `SurfaceView + SubtitleView` — replacing the hardcoded `setUserDefaultTextSize()` — and `PlayerView`'s internal SubtitleView). Scales relative to the user's system caption preference so `1.0` keeps today's behavior exactly. Stored on the backend session; store-only no-op in texture mode (no native SubtitleView there).
- **iOS**: `AVPlayerItem.textStyleRules` with `kCMTextMarkupAttribute_RelativeFontSize` at `scale × 100`, applied live and re-applied to every fresh item in `handleLoad` (the only place items are created — quality/audio/track switches mutate the current item on iOS). Rules cleared at `1.0` so system caption styling stays intact.

Sidecar overlay sizing (`subtitleStyle.fontSize`) is unaffected.

## Testing

- `flutter analyze` clean; all 124 tests pass, including 3 new ones (channel payload, re-send on view recreation, no send at default scale).
- Example app compiles on both platforms (debug APK + iOS simulator build).

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ9WizY5MZ87ET6kPz9BPb