### PR TITLE
Fix native iOS FairPlay license flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **iOS FairPlay now generates a real SPC from the application certificate and
+  HLS `skd://` content identifier.** Content key requests no longer fail when
+  `AVContentKeyRequest.initializationData` is absent, and requests received
+  while the certificate is loading are queued safely.
+- Added configurable Base64 certificate/CKC decoding and form-encoded SPC
+  requests for FairPlay providers such as DoveRunner. Binary request and
+  response formats remain the defaults for backward compatibility.
+
 ## [1.5.2] - 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ await controller.loadUrl(
 | `licenseUrl` | `String` | Yes* | Both | License server URL for key requests (*not required for AES-128) |
 | `certificateUrl` | `String` | Yes (FairPlay) | iOS | Certificate URL for FairPlay DRM |
 | `headers` | `Map<String, String>` | No | Both | HTTP headers for license requests (authentication, etc.) |
+| `certificateEncoding` | `String` | No | iOS | FairPlay certificate response encoding: `'binary'` (default) or `'base64'` |
+| `licenseRequestFormat` | `String` | No | iOS | FairPlay SPC request format: `'binary'` (default) or `'base64Form'` (`spc=<Base64 SPC>`) |
+| `licenseResponseEncoding` | `String` | No | iOS | FairPlay CKC response encoding: `'binary'` (default) or `'base64'` |
 
 ### Platform-Specific Examples
 
@@ -167,6 +170,28 @@ await controller.loadUrl(
 - Certificate is automatically fetched and used for license requests
 - License server must implement FairPlay Streaming protocol
 - Works with HLS streams only
+
+FairPlay license servers do not all use the same HTTP wire format. For example,
+DoveRunner returns Base64 certificate and CKC data and accepts the SPC as a
+form-encoded value:
+
+```dart
+await controller.loadUrl(
+  url: 'https://example.com/fairplay-stream.m3u8',
+  drmConfig: {
+    'type': 'fairplay',
+    'licenseUrl': 'https://license-global.pallycon.com/ri/licenseManager.do',
+    'certificateUrl':
+        'https://license-global.pallycon.com/ri/fpsKeyManager.do?siteId=ABCD',
+    'certificateEncoding': 'base64',
+    'licenseRequestFormat': 'base64Form',
+    'licenseResponseEncoding': 'base64',
+    'headers': {
+      'pallycon-customdata-v2': '<license-token>',
+    },
+  },
+);
+```
 
 #### Android - Widevine
 
@@ -234,7 +259,7 @@ await controller.loadUrl(
 
 1. **Secure License Requests**: Always use HTTPS for license URLs and include authentication headers
 2. **Error Handling**: Implement proper error handling for DRM failures (license denied, network errors, etc.)
-3. **Certificate Management**: For FairPlay, ensure your certificate URL is accessible and returns valid DER-encoded certificates
+3. **Certificate Management**: For FairPlay, ensure your certificate URL is accessible and configure `certificateEncoding` when it returns Base64 instead of binary DER
 4. **Testing**: Test DRM playback on physical devices (simulators may have limitations)
 5. **Platform Differences**: Be aware that FairPlay (iOS) and Widevine (Android) have different license request formats
 

--- a/ios/Classes/Handlers/VideoPlayerDrmHandler.swift
+++ b/ios/Classes/Handlers/VideoPlayerDrmHandler.swift
@@ -7,12 +7,21 @@ class VideoPlayerDrmHandler: NSObject {
     private var contentKeySession: AVContentKeySession?
     private var drmConfig: [String: Any]
     private var certificateData: Data?
+    private var certificateError: Error?
+    private var pendingKeyRequests: [AVContentKeyRequest] = []
     private var certificateUrl: URL?
     private var licenseUrl: URL?
     private var licenseHeaders: [String: String]?
+    private let certificateEncoding: String
+    private let licenseRequestFormat: String
+    private let licenseResponseEncoding: String
+    private let delegateQueue = DispatchQueue(label: "com.better_native_video_player.drm")
     
     init(drmConfig: [String: Any]) {
         self.drmConfig = drmConfig
+        self.certificateEncoding = (drmConfig["certificateEncoding"] as? String)?.lowercased() ?? "binary"
+        self.licenseRequestFormat = (drmConfig["licenseRequestFormat"] as? String)?.lowercased() ?? "binary"
+        self.licenseResponseEncoding = (drmConfig["licenseResponseEncoding"] as? String)?.lowercased() ?? "binary"
         
         // Extract configuration values
         if let licenseUrlString = drmConfig["licenseUrl"] as? String {
@@ -66,39 +75,75 @@ class VideoPlayerDrmHandler: NSObject {
             completion(false, error)
             return
         }
+
+        guard let certificateUrl = certificateUrl else {
+            let error = drmError("Certificate URL is required for FairPlay")
+            completion(false, error)
+            return
+        }
+
+        guard ["binary", "base64"].contains(certificateEncoding) else {
+            let error = drmError("Unsupported FairPlay certificateEncoding: \(certificateEncoding)")
+            completion(false, error)
+            return
+        }
+
+        guard ["binary", "base64form"].contains(licenseRequestFormat) else {
+            let error = drmError("Unsupported FairPlay licenseRequestFormat: \(licenseRequestFormat)")
+            completion(false, error)
+            return
+        }
+
+        guard ["binary", "base64"].contains(licenseResponseEncoding) else {
+            let error = drmError("Unsupported FairPlay licenseResponseEncoding: \(licenseResponseEncoding)")
+            completion(false, error)
+            return
+        }
         
         npLog("🔐 DRM: Setting up FairPlay - License URL: \(licenseUrl.absoluteString)")
         
         // Create content key session
         contentKeySession = AVContentKeySession(keySystem: AVContentKeySystem.fairPlayStreaming)
-        
+
         // Set delegate and queue
-        let delegateQueue = DispatchQueue(label: "com.better_native_video_player.drm")
         contentKeySession?.setDelegate(self, queue: delegateQueue)
         
         // Add asset to content key session
         contentKeySession?.addContentKeyRecipient(asset)
         
-        // Fetch certificate if URL is provided
-        if let certificateUrl = certificateUrl {
-            fetchCertificate(url: certificateUrl) { [weak self] success, error in
-                if success {
-                    npLog("🔐 DRM: Certificate fetched successfully")
+        fetchCertificate(url: certificateUrl) { [weak self] result in
+            guard let self = self else { return }
+
+            self.delegateQueue.async {
+                switch result {
+                case .success(let certificateData):
+                    self.certificateData = certificateData
+                    self.certificateError = nil
+                    npLog("🔐 DRM: Certificate fetched successfully (\(certificateData.count) decoded bytes)")
                     completion(true, nil)
-                } else {
-                    npLog("🔐 DRM: Failed to fetch certificate: \(error?.localizedDescription ?? "unknown error")")
+
+                    let pendingRequests = self.pendingKeyRequests
+                    self.pendingKeyRequests.removeAll()
+                    for keyRequest in pendingRequests {
+                        self.processFairPlayKeyRequest(keyRequest)
+                    }
+                case .failure(let error):
+                    self.certificateError = error
+                    npLog("🔐 DRM: Failed to fetch certificate: \(error.localizedDescription)")
                     completion(false, error)
+
+                    let pendingRequests = self.pendingKeyRequests
+                    self.pendingKeyRequests.removeAll()
+                    for keyRequest in pendingRequests {
+                        keyRequest.processContentKeyResponseError(error)
+                    }
                 }
             }
-        } else {
-            // No certificate URL provided - FairPlay will use default certificate
-            npLog("🔐 DRM: No certificate URL provided, using default FairPlay certificate")
-            completion(true, nil)
         }
     }
     
     /// Fetches the FairPlay application certificate
-    private func fetchCertificate(url: URL, completion: @escaping (Bool, Error?) -> Void) {
+    private func fetchCertificate(url: URL, completion: @escaping (Result<Data, Error>) -> Void) {
         npLog("🔐 DRM: Fetching certificate from: \(url.absoluteString)")
         
         var request = URLRequest(url: url)
@@ -116,26 +161,29 @@ class VideoPlayerDrmHandler: NSObject {
             
             if let error = error {
                 npLog("🔐 DRM: Certificate fetch error: \(error.localizedDescription)")
-                completion(false, error)
+                completion(.failure(error))
                 return
             }
             
             guard let httpResponse = response as? HTTPURLResponse,
                   (200...299).contains(httpResponse.statusCode) else {
                 let error = NSError(domain: "VideoPlayerDrmHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch certificate: Invalid response"])
-                completion(false, error)
+                completion(.failure(error))
                 return
             }
             
             guard let data = data else {
                 let error = NSError(domain: "VideoPlayerDrmHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch certificate: No data"])
-                completion(false, error)
+                completion(.failure(error))
                 return
             }
-            
-            self.certificateData = data
-            npLog("🔐 DRM: Certificate fetched successfully (\(data.count) bytes)")
-            completion(true, nil)
+
+            do {
+                let decodedData = try self.decode(data, encoding: self.certificateEncoding, label: "FairPlay certificate")
+                completion(.success(decodedData))
+            } catch {
+                completion(.failure(error))
+            }
         }
         
         task.resume()
@@ -147,7 +195,176 @@ class VideoPlayerDrmHandler: NSObject {
         // The session will be cleaned up when deallocated
         contentKeySession = nil
         certificateData = nil
+        certificateError = nil
+        pendingKeyRequests.removeAll()
         npLog("🔐 DRM: Cleaned up DRM handler")
+    }
+
+    private func processFairPlayKeyRequest(_ keyRequest: AVContentKeyRequest) {
+        guard let licenseUrl = licenseUrl else {
+            let error = drmError("License URL not configured")
+            npLog("🔐 DRM: Error - \(error.localizedDescription)")
+            keyRequest.processContentKeyResponseError(error)
+            return
+        }
+
+        if let certificateError = certificateError {
+            keyRequest.processContentKeyResponseError(certificateError)
+            return
+        }
+
+        guard let certificateData = certificateData else {
+            npLog("🔐 DRM: Certificate is still loading; queueing content key request")
+            pendingKeyRequests.append(keyRequest)
+            return
+        }
+
+        guard let contentIdentifierData = contentIdentifierData(for: keyRequest) else {
+            let error = drmError("FairPlay content key request has no usable identifier")
+            npLog("🔐 DRM: Error - \(error.localizedDescription)")
+            keyRequest.processContentKeyResponseError(error)
+            return
+        }
+
+        keyRequest.makeStreamingContentKeyRequestData(
+            forApp: certificateData,
+            contentIdentifier: contentIdentifierData,
+            options: nil
+        ) { [weak self] spcData, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                npLog("🔐 DRM: SPC generation failed: \(error.localizedDescription)")
+                keyRequest.processContentKeyResponseError(error)
+                return
+            }
+
+            guard let spcData = spcData else {
+                let error = self.drmError("SPC generation returned no data")
+                npLog("🔐 DRM: Error - \(error.localizedDescription)")
+                keyRequest.processContentKeyResponseError(error)
+                return
+            }
+
+            self.sendLicenseRequest(spcData: spcData, to: licenseUrl, for: keyRequest)
+        }
+    }
+
+    private func contentIdentifierData(for keyRequest: AVContentKeyRequest) -> Data? {
+        if let identifierData = keyRequest.identifier as? Data, !identifierData.isEmpty {
+            return identifierData
+        }
+
+        let identifierString: String
+        if let identifierUrl = keyRequest.identifier as? URL {
+            identifierString = identifierUrl.absoluteString
+        } else if let identifierUrl = keyRequest.identifier as? NSURL {
+            identifierString = identifierUrl.absoluteString ?? ""
+        } else if let value = keyRequest.identifier as? String {
+            identifierString = value
+        } else {
+            return nil
+        }
+
+        let skdPrefix = "skd://"
+        let contentIdentifier: String
+        if identifierString.lowercased().hasPrefix(skdPrefix) {
+            contentIdentifier = String(identifierString.dropFirst(skdPrefix.count))
+        } else {
+            contentIdentifier = identifierString
+        }
+
+        guard !contentIdentifier.isEmpty else { return nil }
+        return contentIdentifier.data(using: .utf8)
+    }
+
+    private func sendLicenseRequest(spcData: Data, to licenseUrl: URL, for keyRequest: AVContentKeyRequest) {
+        var request = URLRequest(url: licenseUrl)
+        request.httpMethod = "POST"
+
+        switch licenseRequestFormat {
+        case "base64form":
+            var formValueAllowedCharacters = CharacterSet.alphanumerics
+            formValueAllowedCharacters.insert(charactersIn: "-._~")
+            guard let encodedSpc = spcData.base64EncodedString().addingPercentEncoding(
+                withAllowedCharacters: formValueAllowedCharacters
+            ), let body = "spc=\(encodedSpc)".data(using: .utf8) else {
+                let error = drmError("Could not encode FairPlay SPC form body")
+                keyRequest.processContentKeyResponseError(error)
+                return
+            }
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        default:
+            request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+            request.httpBody = spcData
+        }
+
+        if let headers = licenseHeaders {
+            for (key, value) in headers {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+        }
+
+        npLog("🔐 DRM: Sending license request to: \(licenseUrl.absoluteString)")
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                npLog("🔐 DRM: License request error: \(error.localizedDescription)")
+                keyRequest.processContentKeyResponseError(error)
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                let error = self.drmError("License request failed with status code: \(statusCode)")
+                npLog("🔐 DRM: License request failed: \(error.localizedDescription)")
+                keyRequest.processContentKeyResponseError(error)
+                return
+            }
+
+            guard let data = data, !data.isEmpty else {
+                let error = self.drmError("No data in license response")
+                npLog("🔐 DRM: License response error: \(error.localizedDescription)")
+                keyRequest.processContentKeyResponseError(error)
+                return
+            }
+
+            do {
+                let ckcData = try self.decode(data, encoding: self.licenseResponseEncoding, label: "FairPlay CKC")
+                let keyResponse = AVContentKeyResponse(fairPlayStreamingKeyResponseData: ckcData)
+                keyRequest.processContentKeyResponse(keyResponse)
+                npLog("🔐 DRM: License response processed successfully")
+            } catch {
+                npLog("🔐 DRM: Error processing license response: \(error.localizedDescription)")
+                keyRequest.processContentKeyResponseError(error)
+            }
+        }.resume()
+    }
+
+    private func decode(_ data: Data, encoding: String, label: String) throws -> Data {
+        guard encoding == "base64" else { return data }
+
+        guard let encodedValue = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let decodedData = Data(base64Encoded: encodedValue),
+              !decodedData.isEmpty else {
+            let responseText = String(data: data, encoding: .utf8)?.prefix(512) ?? ""
+            let suffix = responseText.isEmpty ? "" : ": \(responseText)"
+            throw drmError("Invalid Base64-encoded \(label) response\(suffix)")
+        }
+
+        return decodedData
+    }
+
+    private func drmError(_ message: String) -> NSError {
+        return NSError(
+            domain: "VideoPlayerDrmHandler",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
     }
 }
 
@@ -156,79 +373,7 @@ class VideoPlayerDrmHandler: NSObject {
 extension VideoPlayerDrmHandler: AVContentKeySessionDelegate {
     func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVContentKeyRequest) {
         npLog("🔐 DRM: Content key request received")
-        
-        guard let licenseUrl = licenseUrl else {
-            npLog("🔐 DRM: Error - License URL not available")
-            keyRequest.processContentKeyResponseError(NSError(domain: "VideoPlayerDrmHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "License URL not configured"]))
-            return
-        }
-        
-        // Get the initialization data (SPC - Server Playback Context) from the key request
-        // For FairPlay, this is the data that needs to be sent to the license server
-        guard let initializationData = keyRequest.initializationData else {
-            npLog("🔐 DRM: Error - No initialization data in key request")
-            keyRequest.processContentKeyResponseError(NSError(domain: "VideoPlayerDrmHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "No initialization data"]))
-            return
-        }
-        
-        // For FairPlay, the initialization data (SPC) may need to be wrapped with the certificate
-        // However, AVContentKeySession typically handles this automatically
-        // If manual wrapping is needed, it would be done here
-        var requestData = initializationData
-        
-        // Create license request
-        var request = URLRequest(url: licenseUrl)
-        request.httpMethod = "POST"
-        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        request.httpBody = requestData
-        
-        // Add custom headers if provided
-        if let headers = licenseHeaders {
-            for (key, value) in headers {
-                request.setValue(value, forHTTPHeaderField: key)
-            }
-        }
-        
-        npLog("🔐 DRM: Sending license request to: \(licenseUrl.absoluteString)")
-        
-        // Send license request
-        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
-            guard let self = self else { return }
-            
-            if let error = error {
-                npLog("🔐 DRM: License request error: \(error.localizedDescription)")
-                keyRequest.processContentKeyResponseError(error)
-                return
-            }
-            
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode) else {
-                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                let error = NSError(domain: "VideoPlayerDrmHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "License request failed with status code: \(statusCode)"])
-                npLog("🔐 DRM: License request failed: \(error.localizedDescription)")
-                keyRequest.processContentKeyResponseError(error)
-                return
-            }
-            
-            guard let data = data else {
-                let error = NSError(domain: "VideoPlayerDrmHandler", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data in license response"])
-                npLog("🔐 DRM: License response error: \(error.localizedDescription)")
-                keyRequest.processContentKeyResponseError(error)
-                return
-            }
-            
-            // Process the license response
-            do {
-                let keyResponse = AVContentKeyResponse(fairPlayStreamingKeyResponseData: data)
-                keyRequest.processContentKeyResponse(keyResponse)
-                npLog("🔐 DRM: License response processed successfully")
-            } catch {
-                npLog("🔐 DRM: Error processing license response: \(error.localizedDescription)")
-                keyRequest.processContentKeyResponseError(error)
-            }
-        }
-        
-        task.resume()
+        processFairPlayKeyRequest(keyRequest)
     }
     
     func contentKeySession(_ session: AVContentKeySession, didProvide keyRequest: AVPersistableContentKeyRequest) {
@@ -250,5 +395,3 @@ extension VideoPlayerDrmHandler: AVContentKeySessionDelegate {
         return retryReason.contains("network") || retryReason.contains("timeout")
     }
 }
-
-


### PR DESCRIPTION
## Summary

- Generate FairPlay SPC data with AVContentKeyRequest.makeStreamingContentKeyRequestData instead of treating optional initializationData as the SPC.
- Derive the content identifier from the HLS skd:// key URI.
- Queue content-key requests that arrive while the application certificate is loading.
- Add opt-in FairPlay certificate, request, and response encodings while preserving binary defaults.
- Document the new options and a DoveRunner configuration example.

## Problem

On native iOS playback, AVFoundation can provide a FairPlay content-key request with no initializationData. The existing implementation treated that property as an already-created SPC and failed before contacting the license server.

Apple provides makeStreamingContentKeyRequestData(forApp:contentIdentifier:options:) to create the SPC from the application certificate and content identifier:

https://developer.apple.com/documentation/avfoundation/avcontentkeyrequest/makestreamingcontentkeyrequestdata%28forapp%3Acontentidentifier%3Aoptions%3Acompletionhandler%3A%29

## Provider wire formats

Binary certificate, SPC, and CKC formats remain the defaults. Providers can opt into Base64 certificate and response data plus a form-encoded SPC request. The base64Form request body is spc=<percent-encoded Base64 SPC>, matching DoveRunner's native FairPlay integration specification:

https://pallycon.com/docs/en/multidrm/clients/multidrm-native-integration/

## Validation

- All 134 plugin tests passed.
- Dart analysis of lib completed with no errors; four existing info-level lints remain.
- An unsigned debug iOS device build completed successfully through a Flutter POC.
- POC DRM API and widget tests passed.
- Verified form encoding escapes Base64 plus, slash, and equals characters.

Physical-device license acquisition remains the final integration check because FairPlay is unavailable to unit tests.