### PR TITLE
iOS: add AirPlay idle keep-alive for paused sessions (fixes #54)

### DIFF
--- a/ios/Classes/Handlers/VideoPlayerMethodHandler+AirPlay.swift
+++ b/ios/Classes/Handlers/VideoPlayerMethodHandler+AirPlay.swift
@@ -129,4 +129,25 @@ extension VideoPlayerView {
             result(FlutterError(code: "NOT_SUPPORTED", message: "AirPlay detection requires iOS 11.0+", details: nil))
         }
     }
+
+    /// Enables/disables the native idle keep-alive that prevents some
+    /// third-party AirPlay receivers (e.g. Samsung Crystal UHD) from
+    /// dropping the route ~30s after the user pauses (issue #54). See
+    /// SharedPlayerManager's AirPlay Idle Keep-Alive section for the
+    /// nudge implementation.
+    func handleSetAirPlayIdleKeepAliveEnabled(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let arguments = call.arguments as? [String: Any],
+              let enabled = arguments["enabled"] as? Bool else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Invalid arguments", details: nil))
+            return
+        }
+
+        guard let controllerIdValue = controllerId else {
+            result(FlutterError(code: "NO_CONTROLLER", message: "Controller not initialized", details: nil))
+            return
+        }
+
+        SharedPlayerManager.shared.setAirPlayIdleKeepAliveEnabled(for: controllerIdValue, enabled: enabled)
+        result(nil)
+    }
 }

--- a/ios/Classes/Handlers/VideoPlayerMethodHandler+Playback.swift
+++ b/ios/Classes/Handlers/VideoPlayerMethodHandler+Playback.swift
@@ -23,6 +23,13 @@ extension VideoPlayerView {
         player?.rate = desiredPlaybackSpeed
         npLog("Applied playback rate: \(player?.rate ?? 0)")
         updateNowPlayingPlaybackTime()
+
+        // Real playback resumed - the AirPlay idle keep-alive nudge is no
+        // longer needed (see issue #54).
+        if let controllerIdValue = controllerId {
+            SharedPlayerManager.shared.stopKeepAliveTimer(for: controllerIdValue)
+        }
+
         // Play event will be sent automatically by timeControlStatus observer
         result(nil)
     }
@@ -30,6 +37,14 @@ extension VideoPlayerView {
     func handlePause(result: @escaping FlutterResult) {
         player?.pause()
         updateNowPlayingPlaybackTime()
+
+        // If AirPlay idle keep-alive is enabled for this controller and an
+        // external route is currently active, start nudging so third-party
+        // receivers (e.g. Samsung Crystal UHD) don't drop the route after
+        // their idle timeout (see issue #54).
+        if let controllerIdValue = controllerId {
+            SharedPlayerManager.shared.startKeepAliveTimerIfAppropriate(for: controllerIdValue)
+        }
 
         // DON'T disable automatic PiP on pause anymore
         // The system will handle when to trigger automatic PiP based on playback state

--- a/ios/Classes/Handlers/VideoPlayerObserver.swift
+++ b/ios/Classes/Handlers/VideoPlayerObserver.swift
@@ -157,6 +157,16 @@ extension VideoPlayerView {
             case "timeControlStatus":
                 guard let player = player else { return }
 
+                // The AirPlay idle keep-alive nudge (issue #54) briefly sets
+                // player.rate above zero to keep a paused external route
+                // alive, which flips timeControlStatus to .playing and back.
+                // Swallow both synthetic transitions instead of forwarding
+                // them to Flutter or running PiP/Now-Playing side effects.
+                if let controllerIdValue = controllerId,
+                   SharedPlayerManager.shared.isPerformingKeepAliveNudge(for: controllerIdValue) {
+                    return
+                }
+
                 // The texture frame pump only runs while playing (plus
                 // one-shot expectFrame renders while paused)
                 textureRenderer?.setRunning(player.timeControlStatus == .playing)
@@ -266,6 +276,13 @@ extension VideoPlayerView {
                     // lift the viewport quality cap while external playback is on
                     liftViewportCap()
 
+                    // Route just came up while paused - start the idle
+                    // keep-alive if the app opted in (see issue #54). No-op
+                    // if keep-alive isn't enabled or player isn't paused.
+                    if let controllerIdValue = controllerId {
+                        SharedPlayerManager.shared.startKeepAliveTimerIfAppropriate(for: controllerIdValue)
+                    }
+
                     // Try to get device name immediately
                     let deviceName = getAirPlayDeviceName()
                     npLog("📱 Initial device name check: \(deviceName ?? "nil")")
@@ -299,6 +316,11 @@ extension VideoPlayerView {
 
                     // Back to local rendering: restore the viewport quality cap
                     applyViewportCapIfAppropriate()
+
+                    // Route dropped - no external playback left to keep alive.
+                    if let controllerIdValue = controllerId {
+                        SharedPlayerManager.shared.stopKeepAliveTimer(for: controllerIdValue)
+                    }
 
                     var eventData: [String: Any] = ["isConnected": false, "isConnecting": false]
 

--- a/ios/Classes/Manager/SharedPlayerManager.swift
+++ b/ios/Classes/Manager/SharedPlayerManager.swift
@@ -82,6 +82,132 @@ class SharedPlayerManager: NSObject {
     /// These persist to send PiP and AirPlay events even when all views are disposed
     private var controllerEventSinks: [Int: FlutterEventSink] = [:]
 
+    // MARK: - AirPlay Idle Keep-Alive (issue #54)
+
+    /// Per-controller opt-in, set via setAirPlayIdleKeepAliveEnabled. Some
+    /// third-party AirPlay receivers (observed on Samsung Crystal UHD TVs)
+    /// drop the route ~30s after playback is paused. While enabled, a paused
+    /// controller with an active external playback route gets a periodic
+    /// near-zero-rate nudge to keep the receiver's idle timeout from firing.
+    private var keepAliveEnabled: [Int: Bool] = [:]
+
+    /// Active keep-alive timers, one per controller with a running timer.
+    private var keepAliveTimers: [Int: Timer] = [:]
+
+    /// Controllers currently inside a keep-alive rate nudge. The nudge
+    /// briefly sets `player.rate` above zero, which flips `timeControlStatus`
+    /// to `.playing` and back — this set lets observers suppress the
+    /// resulting synthetic play/pause events instead of forwarding them to
+    /// Flutter or triggering PiP-related side effects.
+    private var keepAliveNudgeInProgress: Set<Int> = []
+
+    /// Interval between nudges; shorter than the ~30s idle timeout observed
+    /// on affected receivers, per the issue's suggested approach.
+    private let keepAliveInterval: TimeInterval = 25.0
+
+    /// Rate applied during the nudge. Must be > 0 to keep AVPlayer's
+    /// timeControlStatus as "playing" for the receiver, but small enough
+    /// that no perceptible motion/crawl happens on screen.
+    private let keepAliveNudgeRate: Float = 0.003
+
+    /// How long the nudge holds the non-zero rate before returning to 0.
+    private let keepAliveNudgeDuration: TimeInterval = 0.05
+
+    /// Extra delay after the nudge ends before the suppression flag clears,
+    /// covering the asynchronous delivery of the resulting `.paused` KVO
+    /// notification so that one gets swallowed too.
+    private let keepAliveSuppressionTail: TimeInterval = 0.15
+
+    /// Enables or disables the AirPlay idle keep-alive for a controller.
+    /// Safe to call at any time; only actually starts a timer once the
+    /// controller is both paused and externally active.
+    func setAirPlayIdleKeepAliveEnabled(for controllerId: Int, enabled: Bool) {
+        assertMainThread()
+        keepAliveEnabled[controllerId] = enabled
+        if enabled {
+            startKeepAliveTimerIfAppropriate(for: controllerId)
+        } else {
+            stopKeepAliveTimer(for: controllerId)
+        }
+    }
+
+    /// Starts the keep-alive timer if enabled and the controller is
+    /// currently paused with an active external (AirPlay) route. No-op if a
+    /// timer is already running, or the preconditions aren't met. Safe to
+    /// call speculatively from play/pause/AirPlay-route-change handlers.
+    func startKeepAliveTimerIfAppropriate(for controllerId: Int) {
+        assertMainThread()
+        guard keepAliveEnabled[controllerId] == true else { return }
+        guard keepAliveTimers[controllerId] == nil else { return }
+        guard let player = players[controllerId] else { return }
+        guard player.isExternalPlaybackActive else { return }
+        guard player.timeControlStatus == .paused else { return }
+
+        npLog("💓 [SharedPlayerManager] Starting AirPlay idle keep-alive for controller \(controllerId)")
+        let timer = Timer(timeInterval: keepAliveInterval, repeats: true) { [weak self] _ in
+            self?.performKeepAliveNudge(for: controllerId)
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        keepAliveTimers[controllerId] = timer
+    }
+
+    /// Stops and clears the keep-alive timer for a controller, if running.
+    func stopKeepAliveTimer(for controllerId: Int) {
+        assertMainThread()
+        guard let timer = keepAliveTimers.removeValue(forKey: controllerId) else { return }
+        timer.invalidate()
+        npLog("⏹️ [SharedPlayerManager] Stopped AirPlay idle keep-alive for controller \(controllerId)")
+    }
+
+    /// True while a keep-alive rate nudge for this controller is in flight
+    /// (including its suppression tail). Observers use this to swallow the
+    /// synthetic play/pause blip the nudge produces.
+    func isPerformingKeepAliveNudge(for controllerId: Int) -> Bool {
+        keepAliveNudgeInProgress.contains(controllerId)
+    }
+
+    private func performKeepAliveNudge(for controllerId: Int) {
+        assertMainThread()
+        guard let player = players[controllerId] else {
+            stopKeepAliveTimer(for: controllerId)
+            return
+        }
+
+        // Re-check preconditions each tick: the user may have resumed
+        // playback or the route may have dropped since the timer started.
+        guard keepAliveEnabled[controllerId] == true,
+              player.timeControlStatus == .paused,
+              player.isExternalPlaybackActive else {
+            stopKeepAliveTimer(for: controllerId)
+            return
+        }
+
+        // Skip near end-of-file: nudging this close to the end risks
+        // tripping AVPlayerItemDidPlayToEndTime.
+        if let currentItem = player.currentItem {
+            let duration = CMTimeGetSeconds(currentItem.duration)
+            let position = CMTimeGetSeconds(player.currentTime())
+            if duration.isFinite && duration > 0 && (duration - position) < 1.0 {
+                npLog("⏭️ [SharedPlayerManager] Skipping keep-alive nudge for controller \(controllerId) - near end of file")
+                return
+            }
+        }
+
+        npLog("💓 [SharedPlayerManager] AirPlay idle keep-alive nudge for controller \(controllerId)")
+        keepAliveNudgeInProgress.insert(controllerId)
+        player.rate = keepAliveNudgeRate
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + keepAliveNudgeDuration) { [weak self] in
+            guard let self = self else { return }
+            if let player = self.players[controllerId], player.rate != 0 {
+                player.rate = 0
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.keepAliveSuppressionTail) {
+                self.keepAliveNudgeInProgress.remove(controllerId)
+            }
+        }
+    }
+
     struct PipSettings {
         let allowsPictureInPicture: Bool
         let canStartPictureInPictureAutomatically: Bool
@@ -428,6 +554,11 @@ class SharedPlayerManager: NSObject {
         // Clear manual PiP flag
         controllersWithManualPiP.remove(controllerId)
 
+        // Stop and clear AirPlay idle keep-alive state
+        stopKeepAliveTimer(for: controllerId)
+        keepAliveEnabled.removeValue(forKey: controllerId)
+        keepAliveNudgeInProgress.remove(controllerId)
+
         npLog("✅ [SharedPlayerManager] Fully removed player for controller ID: \(controllerId)")
     }
 
@@ -451,6 +582,13 @@ class SharedPlayerManager: NSObject {
         controllerWithAutomaticPiP = nil
         controllersWithManualPiP.removeAll()
         controllerEventSinks.removeAll()
+
+        for (_, timer) in keepAliveTimers {
+            timer.invalidate()
+        }
+        keepAliveTimers.removeAll()
+        keepAliveEnabled.removeAll()
+        keepAliveNudgeInProgress.removeAll()
     }
 
     // MARK: - AirPlay Route Detection

--- a/ios/Classes/View/VideoPlayerView.swift
+++ b/ios/Classes/View/VideoPlayerView.swift
@@ -724,6 +724,8 @@ import QuartzCore
             handleStartAirPlayDetection(result: result)
         case "stopAirPlayDetection":
             handleStopAirPlayDetection(result: result)
+        case "setAirPlayIdleKeepAliveEnabled":
+            handleSetAirPlayIdleKeepAliveEnabled(call: call, result: result)
         case "dispose":
             handleDispose(result: result)
         default:

--- a/lib/src/controllers/native_video_player_controller.dart
+++ b/lib/src/controllers/native_video_player_controller.dart
@@ -2468,6 +2468,32 @@ class NativeVideoPlayerController {
     await _methodChannel!.disconnectAirPlay();
   }
 
+  /// Enables or disables a native idle keep-alive for paused AirPlay
+  /// sessions (iOS only). On Android, this method does nothing.
+  ///
+  /// Some third-party AirPlay receivers (observed on Samsung Crystal UHD
+  /// TVs) drop the AirPlay route roughly 30 seconds after the user pauses
+  /// playback. When enabled, and only while the player is paused with an
+  /// active AirPlay route, the native layer periodically nudges the
+  /// underlying `AVPlayer`'s rate to a near-zero value and back, which
+  /// keeps the receiver's idle timeout from firing without emitting any
+  /// user-facing play/pause events or visible motion on screen.
+  ///
+  /// This is a native (AVPlayer-level) alternative to nudging playback
+  /// from Dart, which is unreliable on some AirPlay receivers and can
+  /// desync the phone UI from the TV.
+  ///
+  /// Example:
+  /// ```dart
+  /// await controller.setAirPlayIdleKeepAliveEnabled(true);
+  /// ```
+  Future<void> setAirPlayIdleKeepAliveEnabled(bool enabled) async {
+    if (_methodChannel == null) {
+      return;
+    }
+    await _methodChannel!.setAirPlayIdleKeepAliveEnabled(enabled);
+  }
+
   /// Locks the custom overlay to be always visible
   ///
   /// When the overlay is locked, it cannot be dismissed by tapping or by auto-hide timer.

--- a/lib/src/platform/video_player_method_channel.dart
+++ b/lib/src/platform/video_player_method_channel.dart
@@ -492,6 +492,25 @@ class VideoPlayerMethodChannel {
     }
   }
 
+  /// Enables/disables a native idle keep-alive for paused AirPlay sessions
+  /// (iOS only). Some third-party AirPlay receivers drop the route ~30s
+  /// after playback is paused; while enabled, a paused controller with an
+  /// active external route is nudged periodically at the native layer to
+  /// keep the receiver's idle timeout from firing.
+  Future<void> setAirPlayIdleKeepAliveEnabled(bool enabled) async {
+    try {
+      await _methodChannel.invokeMethod<void>(
+        'setAirPlayIdleKeepAliveEnabled',
+        <String, Object>{
+          'viewId': primaryPlatformViewId,
+          'enabled': enabled,
+        },
+      );
+    } catch (e) {
+      debugPrint('Error calling setAirPlayIdleKeepAliveEnabled: $e');
+    }
+  }
+
   /// Starts AirPlay device detection (iOS only)
   ///
   /// Begins monitoring for available AirPlay devices. This should be called


### PR DESCRIPTION
## Summary
Fixes #54 — on some third-party AirPlay receivers (reproduced on Samsung Crystal UHD TVs), pausing playback causes the AirPlay route to drop after ~28-35 seconds due to the receiver's idle timeout.

Adds a native (AVPlayer-level) opt-in idle keep-alive, following the approach outlined in the issue:

- `SharedPlayerManager` tracks a per-controller keep-alive flag and a repeating ~25s timer that only runs while the controller is **paused** and has an **active external (AirPlay) route**.
- Each tick briefly nudges `player.rate` to `0.003` for ~50ms, then back to `0` — enough to keep the receiver's idle timer from firing, without visible motion on screen.
- The nudge is skipped near end-of-file to avoid tripping `AVPlayerItemDidPlayToEndTime`.
- The synthetic `timeControlStatus` transitions the nudge causes (`.paused` → `.playing` → `.paused`) are suppressed in `VideoPlayerObserver` so no spurious `play`/`pause` events reach Flutter, and no PiP/Now-Playing side effects run — avoiding the phone/TV UI desync the issue calls out with Dart-side nudging.
- The timer starts/stops automatically on `play()`, `pause()`, and AirPlay connect/disconnect, and is torn down when the controller is disposed.

## New API
```dart
await controller.setAirPlayIdleKeepAliveEnabled(true);
```
Opt-in and iOS-only; a no-op on Android.

## Test plan
- [x] `dart analyze` on changed Dart files — clean (pre-existing unrelated lint elsewhere)
- [x] `flutter build ios --no-codesign --simulator` on the example app — builds successfully with the Swift changes
- [ ] Manual verification on a physical Samsung Crystal UHD (or similar) receiver, per the issue's repro steps