### PR TITLE
fix(fullscreen): stop the toggle from running twice 

### DIFF
--- a/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerView.kt
+++ b/android/src/main/kotlin/com/huddlecommunity/better_native_video_player/VideoPlayerView.kt
@@ -334,6 +334,19 @@ class VideoPlayerView(
             return
         }
 
+        // Every toggle emits a "fullscreenChange" event, which the Dart
+        // controller may mirror back down the method channel — so a toggle can
+        // arrive here twice. Re-entering while already in that state built a
+        // SECOND Dialog over the first and overwrote the field, orphaning the
+        // original: exitFullscreenNative() then dismissed only the newer one
+        // and the orphan stayed on the window stack as an opaque black
+        // fullscreen window (Theme_Black_NoTitleBar_Fullscreen), which only
+        // the back button could dismiss. Ignore the redundant call.
+        if (enteringFullScreen == isFullScreen) {
+            NpLog.d(TAG, "Ignoring fullscreen toggle - already ${if (isFullScreen) "in" else "out of"} fullscreen")
+            return
+        }
+
         // Get activity from plugin (most reliable) or context
         val activity = NativeVideoPlayerPlugin.getActivity() ?: getActivity(context)
         if (activity == null) {
@@ -398,6 +411,17 @@ class VideoPlayerView(
      */
     private fun enterFullscreenNative(activity: Activity) {
         NpLog.d(TAG, "Entering fullscreen natively")
+
+        // Never leak a previous dialog: the field is reassigned below, so any
+        // dialog still held here would become unreachable and stay showing as
+        // an opaque black window that only the back button could dismiss.
+        fullscreenDialog?.let { stale ->
+            NpLog.w(TAG, "Dismissing stale fullscreen dialog before creating a new one")
+            (videoContentView.parent as? ViewGroup)?.removeView(videoContentView)
+            stale.setOnDismissListener(null)
+            stale.dismiss()
+            fullscreenDialog = null
+        }
 
         // Store original orientation
         originalOrientation = activity.requestedOrientation

--- a/lib/src/controllers/native_video_player_controller.dart
+++ b/lib/src/controllers/native_video_player_controller.dart
@@ -2356,6 +2356,52 @@ class NativeVideoPlayerController {
     }
   }
 
+  /// Applies a fullscreen change that the native side has *already* performed.
+  ///
+  /// The native platform view emits `fullscreenChange` after every toggle,
+  /// including toggles it made itself (the user tapping PlayerView's
+  /// fullscreen button). Routing that event through [enterFullScreen] /
+  /// [exitFullScreen] sent the command straight back down the method channel,
+  /// so one tap ran the native transition twice — on entry that built a second
+  /// fullscreen Dialog over the first, orphaning it as an opaque black window
+  /// that only the back button could dismiss.
+  ///
+  /// This mirrors their bookkeeping — state, Android auto-PiP arming, and
+  /// closing a Dart fullscreen host — without re-issuing the platform call.
+  Future<void> _syncFullScreenFromNative(bool isFullscreen) async {
+    if (_state.isFullScreen == isFullscreen) {
+      return;
+    }
+
+    _updateState(_state.copyWith(isFullScreen: isFullscreen));
+
+    if (!kIsWeb && Platform.isAndroid) {
+      if (isFullscreen) {
+        await _enableAutomaticPiP();
+      } else {
+        _floating.cancelOnLeavePiP();
+        debugPrint('Automatic PiP disabled (native exited fullscreen)');
+      }
+      await _refreshAvailabilityFlags();
+    }
+
+    // A Dart fullscreen host is Dart's to close; native cannot dismiss it.
+    if (!isFullscreen && (_hasCustomOverlay || _usedDartFullscreen)) {
+      _usedDartFullscreen = false;
+      _dartFullscreenCloseCallback?.call();
+    }
+
+    final controlEvent = PlayerControlEvent(
+      state: isFullscreen
+          ? PlayerControlState.fullscreenEntered
+          : PlayerControlState.fullscreenExited,
+      data: <String, dynamic>{'isFullscreen': isFullscreen},
+    );
+    for (final handler in _controlEventHandlers) {
+      handler(controlEvent);
+    }
+  }
+
   /// Enters Dart-based fullscreen mode
   Future<void> _enterDartFullscreen() async {
     final context = _fullscreenContext;

--- a/lib/src/controllers/native_video_player_controller_events.dart
+++ b/lib/src/controllers/native_video_player_controller_events.dart
@@ -425,15 +425,13 @@ extension _ControllerEventPlumbing on NativeVideoPlayerController {
                     unawaited(enterFullScreen());
                   }
                 } else {
-                  // Normal fullscreen change from native side (e.g., PiP exit restoration)
-                  // Actually call the fullscreen methods to sync UI state
-                  if (isFullscreen && !_state.isFullScreen) {
-                    // Native side entered fullscreen, sync Flutter state
-                    unawaited(enterFullScreen());
-                  } else if (!isFullscreen && _state.isFullScreen) {
-                    // Native side exited fullscreen, sync Flutter state
-                    unawaited(exitFullScreen());
-                  }
+                  // Normal fullscreen change from native side (e.g. the user
+                  // tapping PlayerView's own fullscreen button, or PiP exit
+                  // restoration). Native has already performed the transition,
+                  // so only mirror it in Dart — calling enterFullScreen() /
+                  // exitFullScreen() here would send the command back down the
+                  // method channel and run the native transition a second time.
+                  unawaited(_syncFullScreenFromNative(isFullscreen));
                 }
 
                 // Always update state for fullscreen changes


### PR DESCRIPTION
fix(fullscreen): stop the toggle from running twice and leaking a black dialog

Native emitted `fullscreenChange` after every toggle, including ones it
performed itself. The Dart event handler mirrored that event by calling
enterFullScreen()/exitFullScreen(), which sent the command back down the
method channel — so a single tap on PlayerView's fullscreen button ran the
native transition twice.

On entry the second pass built a new Dialog and assigned it over
`fullscreenDialog`, orphaning the first. exitFullscreenNative() dismisses
only the dialog in the field, so the orphan stayed on the window stack as
an opaque Theme_Black_NoTitleBar_Fullscreen window: the app looked black
but stayed interactive underneath, and back dismissed the orphan.

- Route native-initiated changes through _syncFullScreenFromNative(), which
  mirrors state, Android auto-PiP arming and Dart-fullscreen teardown
  without re-issuing the platform call.
- Guard handleFullscreenToggleNative() against re-entry when already in the
  requested state.
- Dismiss any stale dialog in enterFullscreenNative() before reassigning the
  field, so no path can orphan one.